### PR TITLE
Add isolates for JSON parsing

### DIFF
--- a/app/lib/data/services/api/api_client.dart
+++ b/app/lib/data/services/api/api_client.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import '../../../domain/models/activity/activity.dart';
 import '../../../domain/models/continent/continent.dart';
 import '../../../domain/models/destination/destination.dart';
+import '../../../utils/json_isolate.dart';
 import '../../../utils/result.dart';
 import 'model/booking/booking_api_model.dart';
 import 'model/user/user_api_model.dart';
@@ -46,10 +47,11 @@ class ApiClient {
       final response = await request.close();
       if (response.statusCode == 200) {
         final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
-        return Result.ok(
-          json.map((element) => Continent.fromJson(element)).toList(),
+        final continents = await parseJsonListInIsolate(
+          stringData,
+          Continent.fromJson,
         );
+        return Result.ok(continents);
       } else {
         return const Result.error(HttpException("Invalid response"));
       }
@@ -68,10 +70,11 @@ class ApiClient {
       final response = await request.close();
       if (response.statusCode == 200) {
         final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
-        return Result.ok(
-          json.map((element) => Destination.fromJson(element)).toList(),
+        final destinations = await parseJsonListInIsolate(
+          stringData,
+          Destination.fromJson,
         );
+        return Result.ok(destinations);
       } else {
         return const Result.error(HttpException("Invalid response"));
       }
@@ -94,9 +97,10 @@ class ApiClient {
       final response = await request.close();
       if (response.statusCode == 200) {
         final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
-        final activities =
-            json.map((element) => Activity.fromJson(element)).toList();
+        final activities = await parseJsonListInIsolate(
+          stringData,
+          Activity.fromJson,
+        );
         return Result.ok(activities);
       } else {
         return const Result.error(HttpException("Invalid response"));
@@ -116,9 +120,10 @@ class ApiClient {
       final response = await request.close();
       if (response.statusCode == 200) {
         final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
-        final bookings =
-            json.map((element) => BookingApiModel.fromJson(element)).toList();
+        final bookings = await parseJsonListInIsolate(
+          stringData,
+          BookingApiModel.fromJson,
+        );
         return Result.ok(bookings);
       } else {
         return const Result.error(HttpException("Invalid response"));
@@ -138,7 +143,10 @@ class ApiClient {
       final response = await request.close();
       if (response.statusCode == 200) {
         final stringData = await response.transform(utf8.decoder).join();
-        final booking = BookingApiModel.fromJson(jsonDecode(stringData));
+        final booking = await parseJsonMapInIsolate(
+          stringData,
+          BookingApiModel.fromJson,
+        );
         return Result.ok(booking);
       } else {
         return const Result.error(HttpException("Invalid response"));
@@ -159,7 +167,10 @@ class ApiClient {
       final response = await request.close();
       if (response.statusCode == 201) {
         final stringData = await response.transform(utf8.decoder).join();
-        final booking = BookingApiModel.fromJson(jsonDecode(stringData));
+        final booking = await parseJsonMapInIsolate(
+          stringData,
+          BookingApiModel.fromJson,
+        );
         return Result.ok(booking);
       } else {
         return const Result.error(HttpException("Invalid response"));
@@ -179,7 +190,10 @@ class ApiClient {
       final response = await request.close();
       if (response.statusCode == 200) {
         final stringData = await response.transform(utf8.decoder).join();
-        final user = UserApiModel.fromJson(jsonDecode(stringData));
+        final user = await parseJsonMapInIsolate(
+          stringData,
+          UserApiModel.fromJson,
+        );
         return Result.ok(user);
       } else {
         return const Result.error(HttpException("Invalid response"));

--- a/app/lib/data/services/local/local_data_service.dart
+++ b/app/lib/data/services/local/local_data_service.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import '../../../utils/json_isolate.dart';
+
 import 'package:flutter/services.dart';
 
 import '../../../config/assets.dart';
@@ -58,7 +60,7 @@ class LocalDataService {
 
   Future<List<Map<String, dynamic>>> _loadStringAsset(String asset) async {
     final localData = await rootBundle.loadString(asset);
-    return (jsonDecode(localData) as List).cast<Map<String, dynamic>>();
+    return parseMapListInIsolate(localData);
   }
 
   User getUser() {

--- a/app/lib/utils/json_isolate.dart
+++ b/app/lib/utils/json_isolate.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+import 'dart:isolate';
+
+/// Parse a JSON map in an isolate using [fromJson].
+Future<T> parseJsonMapInIsolate<T>(
+  String source,
+  T Function(Map<String, dynamic>) fromJson,
+) {
+  return Isolate.run(() {
+    final map = jsonDecode(source) as Map<String, dynamic>;
+    return fromJson(map);
+  });
+}
+
+/// Parse a JSON list in an isolate using [fromJson].
+Future<List<T>> parseJsonListInIsolate<T>(
+  String source,
+  T Function(Map<String, dynamic>) fromJson,
+) {
+  return Isolate.run(() {
+    final list = jsonDecode(source) as List<dynamic>;
+    return list.map((e) => fromJson(e as Map<String, dynamic>)).toList();
+  });
+}
+
+/// Decode a JSON list into a list of maps in an isolate.
+Future<List<Map<String, dynamic>>> parseMapListInIsolate(String source) {
+  return Isolate.run(() {
+    return (jsonDecode(source) as List).cast<Map<String, dynamic>>();
+  });
+}

--- a/app/test/utils/json_isolate_test.dart
+++ b/app/test/utils/json_isolate_test.dart
@@ -1,0 +1,36 @@
+import 'package:compass_app/utils/json_isolate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('JsonIsolate utilities', () {
+    test('should parse map using isolate', () async {
+      const data = '{"a":1}';
+      final result = await parseJsonMapInIsolate<Map<String, dynamic>>(
+        data,
+        (e) => e,
+      );
+      expect(result, {'a': 1});
+    });
+
+    test('should parse list using isolate', () async {
+      const data = '[{"a":1},{"a":2}]';
+      final list = await parseJsonListInIsolate<Map<String, dynamic>>(
+        data,
+        (e) => e,
+      );
+      expect(list, [
+        {'a': 1},
+        {'a': 2},
+      ]);
+    });
+
+    test('should parse map list using isolate', () async {
+      const data = '[{"a":1},{"a":2}]';
+      final list = await parseMapListInIsolate(data);
+      expect(list, [
+        {'a': 1},
+        {'a': 2},
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add generic isolate helpers for JSON decoding
- parse HTTP and asset JSON using isolates
- cover isolate utilities with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc8a35bac8322a9bd74584e0d47f8