### PR TITLE
Use http Client for web compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,23 +1,69 @@
+// {
+//   "configurations": [
+//     {
+//       "name": "Web Development",
+//       "type": "dart",
+//       "request": "launch",
+//       "program": "app/lib/main_development.dart",
+//       "args": ["-d", "chrome", "--web-experimental-hot-reload"]
+//     },
+//     {
+//       "name": "Web Staging",
+//       "type": "dart",
+//       "request": "launch",
+//       "program": "app/lib/main_staging.dart",
+//       "args": ["-d", "chrome", "--web-experimental-hot-reload"]
+//     },
+//     {
+//       "name": "Development",
+//       "type": "dart",
+//       "request": "launch",
+//       "program": "app/lib/main_development.dart"
+//     },
+//     {
+//       "name": "Staging",
+//       "type": "dart",
+//       "request": "launch",
+//       "program": "app/lib/main_staging.dart"
+//     }
+//   ]
+// }
+
 {
   "configurations": [
-    {
-      "name": "Development",
-      "type": "dart",
-      "request": "launch",
-      "program": "app/lib/main_development.dart"
-    },
-    {
-      "name": "Staging",
-      "type": "dart",
-      "request": "launch",
-      "program": "app/lib/main_staging.dart"
-    },
     {
       "name": "Web Development",
       "type": "dart",
       "request": "launch",
       "program": "app/lib/main_development.dart",
       "args": ["-d", "chrome", "--web-experimental-hot-reload"]
+    },
+    {
+      "name": "iOS Development",
+      "type": "dart",
+      "request": "launch",
+      "program": "app/lib/main_development.dart",
+      "args": ["-d", "ios"]
+    },
+    {
+      "name": "Web Staging",
+      "type": "dart",
+      "request": "launch",
+      "program": "app/lib/main_staging.dart",
+      "args": ["-d", "chrome", "--web-experimental-hot-reload"]
+    },
+    {
+      "name": "iOS Staging",
+      "type": "dart",
+      "request": "launch",
+      "program": "app/lib/main_staging.dart",
+      // "args": ["-d", "ios"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Web + iOS Staging",
+      "configurations": ["Web Staging", "iOS Staging"],
     }
   ]
 }

--- a/app/lib/data/services/api/api_client.dart
+++ b/app/lib/data/services/api/api_client.dart
@@ -18,9 +18,9 @@ typedef AuthHeaderProvider = String? Function();
 
 class ApiClient {
   ApiClient({String? host, int? port, http.Client Function()? clientFactory})
-      : _host = host ?? 'localhost',
-        _port = port ?? 8080,
-        _clientFactory = clientFactory ?? http.Client.new;
+    : _host = host ?? 'localhost',
+      _port = port ?? 8080,
+      _clientFactory = clientFactory ?? http.Client.new;
 
   final String _host;
   final int _port;
@@ -44,11 +44,9 @@ class ApiClient {
       final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as List<dynamic>;
-        return Result.ok(
-          json.map((e) => Continent.fromJson(e)).toList(),
-        );
+        return Result.ok(json.map((e) => Continent.fromJson(e)).toList());
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -64,11 +62,9 @@ class ApiClient {
       final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as List<dynamic>;
-        return Result.ok(
-          json.map((e) => Destination.fromJson(e)).toList(),
-        );
+        return Result.ok(json.map((e) => Destination.fromJson(e)).toList());
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -84,11 +80,9 @@ class ApiClient {
       final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as List<dynamic>;
-        return Result.ok(
-          json.map((e) => Activity.fromJson(e)).toList(),
-        );
+        return Result.ok(json.map((e) => Activity.fromJson(e)).toList());
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -104,11 +98,9 @@ class ApiClient {
       final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as List<dynamic>;
-        return Result.ok(
-          json.map((e) => BookingApiModel.fromJson(e)).toList(),
-        );
+        return Result.ok(json.map((e) => BookingApiModel.fromJson(e)).toList());
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -126,7 +118,7 @@ class ApiClient {
         final booking = BookingApiModel.fromJson(jsonDecode(response.body));
         return Result.ok(booking);
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -141,17 +133,14 @@ class ApiClient {
       final uri = Uri.http('$_host:$_port', '/booking');
       final response = await client.post(
         uri,
-        headers: {
-          ..._authHeader(),
-          'Content-Type': 'application/json',
-        },
+        headers: {..._authHeader(), 'Content-Type': 'application/json'},
         body: jsonEncode(booking),
       );
       if (response.statusCode == 201) {
         final result = BookingApiModel.fromJson(jsonDecode(response.body));
         return Result.ok(result);
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -169,7 +158,7 @@ class ApiClient {
         final user = UserApiModel.fromJson(jsonDecode(response.body));
         return Result.ok(user);
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -186,7 +175,7 @@ class ApiClient {
       if (response.statusCode == 204) {
         return const Result.ok(null);
       } else {
-        return const Result.error(Exception('Invalid response'));
+        return Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);

--- a/app/lib/data/services/api/api_client.dart
+++ b/app/lib/data/services/api/api_client.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
+
+import 'package:http/http.dart' as http;
 
 import '../../../domain/models/activity/activity.dart';
 import '../../../domain/models/continent/continent.dart';
@@ -16,14 +17,14 @@ import 'model/user/user_api_model.dart';
 typedef AuthHeaderProvider = String? Function();
 
 class ApiClient {
-  ApiClient({String? host, int? port, HttpClient Function()? clientFactory})
-    : _host = host ?? 'localhost',
-      _port = port ?? 8080,
-      _clientFactory = clientFactory ?? HttpClient.new;
+  ApiClient({String? host, int? port, http.Client Function()? clientFactory})
+      : _host = host ?? 'localhost',
+        _port = port ?? 8080,
+        _clientFactory = clientFactory ?? http.Client.new;
 
   final String _host;
   final int _port;
-  final HttpClient Function() _clientFactory;
+  final http.Client Function() _clientFactory;
 
   AuthHeaderProvider? _authHeaderProvider;
 
@@ -31,27 +32,23 @@ class ApiClient {
     _authHeaderProvider = authHeaderProvider;
   }
 
-  Future<void> _authHeader(HttpHeaders headers) async {
+  Map<String, String> _authHeader() {
     final header = _authHeaderProvider?.call();
-    if (header != null) {
-      headers.add(HttpHeaders.authorizationHeader, header);
-    }
+    return header != null ? {'Authorization': header} : <String, String>{};
   }
 
   Future<Result<List<Continent>>> getContinents() async {
     final client = _clientFactory();
     try {
-      final request = await client.get(_host, _port, '/continent');
-      await _authHeader(request.headers);
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/continent');
+      final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
-        final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
+        final json = jsonDecode(response.body) as List<dynamic>;
         return Result.ok(
-          json.map((element) => Continent.fromJson(element)).toList(),
+          json.map((e) => Continent.fromJson(e)).toList(),
         );
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -63,17 +60,15 @@ class ApiClient {
   Future<Result<List<Destination>>> getDestinations() async {
     final client = _clientFactory();
     try {
-      final request = await client.get(_host, _port, '/destination');
-      await _authHeader(request.headers);
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/destination');
+      final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
-        final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
+        final json = jsonDecode(response.body) as List<dynamic>;
         return Result.ok(
-          json.map((element) => Destination.fromJson(element)).toList(),
+          json.map((e) => Destination.fromJson(e)).toList(),
         );
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -85,21 +80,15 @@ class ApiClient {
   Future<Result<List<Activity>>> getActivityByDestination(String ref) async {
     final client = _clientFactory();
     try {
-      final request = await client.get(
-        _host,
-        _port,
-        '/destination/$ref/activity',
-      );
-      await _authHeader(request.headers);
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/destination/$ref/activity');
+      final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
-        final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
-        final activities =
-            json.map((element) => Activity.fromJson(element)).toList();
-        return Result.ok(activities);
+        final json = jsonDecode(response.body) as List<dynamic>;
+        return Result.ok(
+          json.map((e) => Activity.fromJson(e)).toList(),
+        );
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -111,17 +100,15 @@ class ApiClient {
   Future<Result<List<BookingApiModel>>> getBookings() async {
     final client = _clientFactory();
     try {
-      final request = await client.get(_host, _port, '/booking');
-      await _authHeader(request.headers);
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/booking');
+      final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
-        final stringData = await response.transform(utf8.decoder).join();
-        final json = jsonDecode(stringData) as List<dynamic>;
-        final bookings =
-            json.map((element) => BookingApiModel.fromJson(element)).toList();
-        return Result.ok(bookings);
+        final json = jsonDecode(response.body) as List<dynamic>;
+        return Result.ok(
+          json.map((e) => BookingApiModel.fromJson(e)).toList(),
+        );
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -133,15 +120,13 @@ class ApiClient {
   Future<Result<BookingApiModel>> getBooking(int id) async {
     final client = _clientFactory();
     try {
-      final request = await client.get(_host, _port, '/booking/$id');
-      await _authHeader(request.headers);
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/booking/$id');
+      final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
-        final stringData = await response.transform(utf8.decoder).join();
-        final booking = BookingApiModel.fromJson(jsonDecode(stringData));
+        final booking = BookingApiModel.fromJson(jsonDecode(response.body));
         return Result.ok(booking);
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -153,16 +138,20 @@ class ApiClient {
   Future<Result<BookingApiModel>> postBooking(BookingApiModel booking) async {
     final client = _clientFactory();
     try {
-      final request = await client.post(_host, _port, '/booking');
-      await _authHeader(request.headers);
-      request.write(jsonEncode(booking));
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/booking');
+      final response = await client.post(
+        uri,
+        headers: {
+          ..._authHeader(),
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode(booking),
+      );
       if (response.statusCode == 201) {
-        final stringData = await response.transform(utf8.decoder).join();
-        final booking = BookingApiModel.fromJson(jsonDecode(stringData));
-        return Result.ok(booking);
+        final result = BookingApiModel.fromJson(jsonDecode(response.body));
+        return Result.ok(result);
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -174,15 +163,13 @@ class ApiClient {
   Future<Result<UserApiModel>> getUser() async {
     final client = _clientFactory();
     try {
-      final request = await client.get(_host, _port, '/user');
-      await _authHeader(request.headers);
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/user');
+      final response = await client.get(uri, headers: _authHeader());
       if (response.statusCode == 200) {
-        final stringData = await response.transform(utf8.decoder).join();
-        final user = UserApiModel.fromJson(jsonDecode(stringData));
+        final user = UserApiModel.fromJson(jsonDecode(response.body));
         return Result.ok(user);
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);
@@ -194,14 +181,12 @@ class ApiClient {
   Future<Result<void>> deleteBooking(int id) async {
     final client = _clientFactory();
     try {
-      final request = await client.delete(_host, _port, '/booking/$id');
-      await _authHeader(request.headers);
-      final response = await request.close();
-      // Response 204 "No Content", delete was successful
+      final uri = Uri.http('$_host:$_port', '/booking/$id');
+      final response = await client.delete(uri, headers: _authHeader());
       if (response.statusCode == 204) {
         return const Result.ok(null);
       } else {
-        return const Result.error(HttpException("Invalid response"));
+        return const Result.error(Exception('Invalid response'));
       }
     } on Exception catch (error) {
       return Result.error(error);

--- a/app/lib/data/services/api/auth_api_client.dart
+++ b/app/lib/data/services/api/auth_api_client.dart
@@ -3,33 +3,38 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
+
+import 'package:http/http.dart' as http;
 
 import '../../../utils/result.dart';
 import 'model/login_request/login_request.dart';
 import 'model/login_response/login_response.dart';
 
 class AuthApiClient {
-  AuthApiClient({String? host, int? port, HttpClient Function()? clientFactory})
-    : _host = host ?? 'localhost',
-      _port = port ?? 8080,
-      _clientFactory = clientFactory ?? HttpClient.new;
+  AuthApiClient({String? host, int? port, http.Client Function()? clientFactory})
+      : _host = host ?? 'localhost',
+        _port = port ?? 8080,
+        _clientFactory = clientFactory ?? http.Client.new;
 
   final String _host;
   final int _port;
-  final HttpClient Function() _clientFactory;
+  final http.Client Function() _clientFactory;
 
   Future<Result<LoginResponse>> login(LoginRequest loginRequest) async {
     final client = _clientFactory();
     try {
-      final request = await client.post(_host, _port, '/login');
-      request.write(jsonEncode(loginRequest));
-      final response = await request.close();
+      final uri = Uri.http('$_host:$_port', '/login');
+      final response = await client.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(loginRequest),
+      );
       if (response.statusCode == 200) {
-        final stringData = await response.transform(utf8.decoder).join();
-        return Result.ok(LoginResponse.fromJson(jsonDecode(stringData)));
+        return Result.ok(
+          LoginResponse.fromJson(jsonDecode(response.body)),
+        );
       } else {
-        return const Result.error(HttpException("Login error"));
+        return const Result.error(Exception('Login error'));
       }
     } on Exception catch (error) {
       return Result.error(error);

--- a/app/lib/data/services/api/auth_api_client.dart
+++ b/app/lib/data/services/api/auth_api_client.dart
@@ -11,10 +11,13 @@ import 'model/login_request/login_request.dart';
 import 'model/login_response/login_response.dart';
 
 class AuthApiClient {
-  AuthApiClient({String? host, int? port, http.Client Function()? clientFactory})
-      : _host = host ?? 'localhost',
-        _port = port ?? 8080,
-        _clientFactory = clientFactory ?? http.Client.new;
+  AuthApiClient({
+    String? host,
+    int? port,
+    http.Client Function()? clientFactory,
+  }) : _host = host ?? 'localhost',
+       _port = port ?? 8080,
+       _clientFactory = clientFactory ?? http.Client.new;
 
   final String _host;
   final int _port;
@@ -30,11 +33,9 @@ class AuthApiClient {
         body: jsonEncode(loginRequest),
       );
       if (response.statusCode == 200) {
-        return Result.ok(
-          LoginResponse.fromJson(jsonDecode(response.body)),
-        );
+        return Result.ok(LoginResponse.fromJson(jsonDecode(response.body)));
       } else {
-        return const Result.error(Exception('Login error'));
+        return Result.error(Exception('Login error'));
       }
     } on Exception catch (error) {
       return Result.error(error);

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -344,7 +344,7 @@ packages:
     source: hosted
     version: "2.3.2"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   intl: any
   json_annotation: ^4.9.0
   logging: ^1.3.0
+  http: ^1.1.0
   provider: ^6.1.2
   share_plus: ^10.1.3
   shared_preferences: ^2.3.5

--- a/app/testing/mocks.dart
+++ b/app/testing/mocks.dart
@@ -3,58 +3,34 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
+
+import 'package:http/http.dart' as http;
 
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockGoRouter extends Mock implements GoRouter {}
 
-class MockHttpClient extends Mock implements HttpClient {}
-
-class MockHttpHeaders extends Mock implements HttpHeaders {}
-
-class MockHttpClientRequest extends Mock implements HttpClientRequest {}
-
-class MockHttpClientResponse extends Mock implements HttpClientResponse {}
+class MockHttpClient extends Mock implements http.Client {}
 
 extension HttpMethodMocks on MockHttpClient {
   void mockGet(String path, Object object) {
-    when(() => get(any(), any(), path)).thenAnswer((invocation) {
-      final request = MockHttpClientRequest();
-      final response = MockHttpClientResponse();
-      when(() => request.close()).thenAnswer((_) => Future.value(response));
-      when(() => request.headers).thenReturn(MockHttpHeaders());
-      when(() => response.statusCode).thenReturn(200);
-      when(
-        () => response.transform(utf8.decoder),
-      ).thenAnswer((_) => Stream.value(jsonEncode(object)));
-      return Future.value(request);
-    });
+    when(() => get(Uri.http('localhost:8080', path), headers: any(named: 'headers')))
+        .thenAnswer((_) async => http.Response(jsonEncode(object), 200));
   }
 
   void mockPost(String path, Object object, [int statusCode = 201]) {
-    when(() => post(any(), any(), path)).thenAnswer((invocation) {
-      final request = MockHttpClientRequest();
-      final response = MockHttpClientResponse();
-      when(() => request.close()).thenAnswer((_) => Future.value(response));
-      when(() => request.headers).thenReturn(MockHttpHeaders());
-      when(() => response.statusCode).thenReturn(statusCode);
-      when(
-        () => response.transform(utf8.decoder),
-      ).thenAnswer((_) => Stream.value(jsonEncode(object)));
-      return Future.value(request);
-    });
+    when(() => post(
+          Uri.http('localhost:8080', path),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        )).thenAnswer(
+      (_) async => http.Response(jsonEncode(object), statusCode),
+    );
   }
 
   void mockDelete(String path) {
-    when(() => delete(any(), any(), path)).thenAnswer((invocation) {
-      final request = MockHttpClientRequest();
-      final response = MockHttpClientResponse();
-      when(() => request.close()).thenAnswer((_) => Future.value(response));
-      when(() => request.headers).thenReturn(MockHttpHeaders());
-      when(() => response.statusCode).thenReturn(204);
-      return Future.value(request);
-    });
+    when(() => delete(Uri.http('localhost:8080', path), headers: any(named: 'headers')))
+        .thenAnswer((_) async => http.Response('', 204));
   }
 }

--- a/documentation/CompassApp/Prompts/Codex.md
+++ b/documentation/CompassApp/Prompts/Codex.md
@@ -1,0 +1,10 @@
+Tarefa:
+
+
+**Requisitos para a resposta:**
+
+* Retorne o código completo implementado, incluindo o arquivo de testes.
+* O código deve ser totalmente documentado, com comentários em inglês.
+* Toda e qualquer modificação no código, nomes de variáveis, mensagens de commit, nome da branch e descrição do pull request devem estar em inglês.
+* Não traduza ou escreva nenhum trecho do código em português.
+* No chat, explique em português, de forma objetiva, o que foi implementado e como a nova lógica funciona.

--- a/documentation/CompassApp/Versioning.md
+++ b/documentation/CompassApp/Versioning.md
@@ -17,3 +17,7 @@
 	Related files:
 	- integration_test/app_local_data_test.dart
 	- integration_test/app_server_data_test.dart
+- [x] Add isolate helpers for JSON parsing
+- [x] Replace HttpClient with cross-platform http package
+- [x] Add CORS middleware and tests
+- [x] 0.1.7; refactor(cross-platform): fix runtime errors and add new launch configuration

--- a/server/bin/compass_server.dart
+++ b/server/bin/compass_server.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:compass_server/middleware/auth.dart';
+import 'package:compass_server/middleware/cors.dart';
 import 'package:compass_server/routes/booking.dart';
 import 'package:compass_server/routes/continent.dart';
 import 'package:compass_server/routes/destination.dart';
@@ -30,6 +31,7 @@ void main(List<String> args) async {
   // Configure a pipeline that logs requests.
   final handler = Pipeline()
       .addMiddleware(logRequests())
+      .addMiddleware(cors())
       .addMiddleware(authRequests())
       .addHandler(_router.call);
 

--- a/server/lib/middleware/cors.dart
+++ b/server/lib/middleware/cors.dart
@@ -1,0 +1,20 @@
+import 'package:shelf/shelf.dart';
+
+/// Middleware that adds basic CORS headers and handles preflight requests.
+Middleware cors() => (Handler innerHandler) {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+  };
+
+  return (Request request) async {
+    // Handle preflight CORS requests by returning early with headers.
+    if (request.method == 'OPTIONS') {
+      return Response.ok('', headers: corsHeaders);
+    }
+
+    final response = await innerHandler(request);
+    return response.change(headers: corsHeaders);
+  };
+};

--- a/server/test/server_test.dart
+++ b/server/test/server_test.dart
@@ -200,4 +200,13 @@ void main() {
 
     expect(response.statusCode, 401);
   });
+
+  test('CORS preflight', () async {
+    final client = Client();
+    final req = Request('OPTIONS', Uri.parse('$host/login'));
+    final streamed = await client.send(req);
+    final res = await Response.fromStream(streamed);
+    expect(res.statusCode, 200);
+    expect(res.headers['access-control-allow-origin'], '*');
+  });
 }


### PR DESCRIPTION
## Summary
- replace dart:io HttpClient with the http package
- update mocks and tests to work with http.Client
- include http dependency in pubspec

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcba569148322a30d187739e7f8cf