### PR TITLE
Refactor repeated server and client logic

### DIFF
--- a/app/lib/data/services/api/api_client.dart
+++ b/app/lib/data/services/api/api_client.dart
@@ -39,20 +39,17 @@ class ApiClient {
     return header != null ? {'Authorization': header} : <String, String>{};
   }
 
-  Future<Result<List<Continent>>> getContinents() async {
+  Future<Result<T>> _send<T>(
+    Future<http.Response> Function(http.Client) requestFn,
+    Future<T> Function(String body) parse,
+    int expectedStatus,
+  ) async {
     final client = _clientFactory();
     try {
-      final uri = Uri.http('$_host:$_port', '/continent');
-      final response = await client.get(uri, headers: _authHeader());
-      if (response.statusCode == 200) {
-        final stringData = utf8.decode(response.bodyBytes);
-        final continents =
-            kIsWeb
-                ? (jsonDecode(stringData) as List)
-                    .map((e) => Continent.fromJson(e))
-                    .toList()
-                : await parseJsonListInIsolate(stringData, Continent.fromJson);
-        return Result.ok(continents);
+      final response = await requestFn(client);
+      if (response.statusCode == expectedStatus) {
+        final data = await parse(utf8.decode(response.bodyBytes));
+        return Result.ok(data);
       } else {
         return Result.error(Exception('Invalid response'));
       }
@@ -63,175 +60,14 @@ class ApiClient {
     }
   }
 
-  Future<Result<List<Destination>>> getDestinations() async {
+  Future<Result<void>> _sendVoid(
+    Future<http.Response> Function(http.Client) requestFn,
+    int expectedStatus,
+  ) async {
     final client = _clientFactory();
     try {
-      final uri = Uri.http('$_host:$_port', '/destination');
-      final response = await client.get(uri, headers: _authHeader());
-      if (response.statusCode == 200) {
-        final stringData = utf8.decode(response.bodyBytes);
-        final destinations =
-            kIsWeb
-                ? (jsonDecode(stringData) as List)
-                    .map((e) => Destination.fromJson(e))
-                    .toList()
-                : await parseJsonListInIsolate(
-                  stringData,
-                  Destination.fromJson,
-                );
-        return Result.ok(destinations);
-      } else {
-        return Result.error(Exception('Invalid response'));
-      }
-    } on Exception catch (error) {
-      return Result.error(error);
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<Result<List<Activity>>> getActivityByDestination(String ref) async {
-    final client = _clientFactory();
-    try {
-      final uri = Uri.http('$_host:$_port', '/destination/$ref/activity');
-      final response = await client.get(uri, headers: _authHeader());
-      if (response.statusCode == 200) {
-        final stringData = utf8.decode(response.bodyBytes);
-        final activities =
-            kIsWeb
-                ? (jsonDecode(stringData) as List)
-                    .map((e) => Activity.fromJson(e))
-                    .toList()
-                : await parseJsonListInIsolate(stringData, Activity.fromJson);
-        return Result.ok(activities);
-      } else {
-        return Result.error(Exception('Invalid response'));
-      }
-    } on Exception catch (error) {
-      return Result.error(error);
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<Result<List<BookingApiModel>>> getBookings() async {
-    final client = _clientFactory();
-    try {
-      final uri = Uri.http('$_host:$_port', '/booking');
-      final response = await client.get(uri, headers: _authHeader());
-      if (response.statusCode == 200) {
-        final stringData = utf8.decode(response.bodyBytes);
-        final bookings =
-            kIsWeb
-                ? (jsonDecode(stringData) as List)
-                    .map((e) => BookingApiModel.fromJson(e))
-                    .toList()
-                : await parseJsonListInIsolate(
-                  stringData,
-                  BookingApiModel.fromJson,
-                );
-        return Result.ok(bookings);
-      } else {
-        return Result.error(Exception('Invalid response'));
-      }
-    } on Exception catch (error) {
-      return Result.error(error);
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<Result<BookingApiModel>> getBooking(int id) async {
-    final client = _clientFactory();
-    try {
-      final uri = Uri.http('$_host:$_port', '/booking/$id');
-      final response = await client.get(uri, headers: _authHeader());
-      if (response.statusCode == 200) {
-        final stringData = utf8.decode(response.bodyBytes);
-        final booking =
-            kIsWeb
-                ? BookingApiModel.fromJson(
-                  jsonDecode(stringData) as Map<String, dynamic>,
-                )
-                : await parseJsonMapInIsolate(
-                  stringData,
-                  BookingApiModel.fromJson,
-                );
-        return Result.ok(booking);
-      } else {
-        return Result.error(Exception('Invalid response'));
-      }
-    } on Exception catch (error) {
-      return Result.error(error);
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<Result<BookingApiModel>> postBooking(BookingApiModel booking) async {
-    final client = _clientFactory();
-    try {
-      final uri = Uri.http('$_host:$_port', '/booking');
-      final response = await client.post(
-        uri,
-        headers: {..._authHeader(), 'Content-Type': 'application/json'},
-        body: jsonEncode(booking),
-      );
-      if (response.statusCode == 201) {
-        final stringData = utf8.decode(response.bodyBytes);
-        final booking =
-            kIsWeb
-                ? BookingApiModel.fromJson(
-                  jsonDecode(stringData) as Map<String, dynamic>,
-                )
-                : await parseJsonMapInIsolate(
-                  stringData,
-                  BookingApiModel.fromJson,
-                );
-        return Result.ok(booking);
-      } else {
-        return Result.error(Exception('Invalid response'));
-      }
-    } on Exception catch (error) {
-      return Result.error(error);
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<Result<UserApiModel>> getUser() async {
-    final client = _clientFactory();
-    try {
-      final uri = Uri.http('$_host:$_port', '/user');
-      final response = await client.get(uri, headers: _authHeader());
-      if (response.statusCode == 200) {
-        final stringData = utf8.decode(response.bodyBytes);
-        final user =
-            kIsWeb
-                ? UserApiModel.fromJson(
-                  jsonDecode(stringData) as Map<String, dynamic>,
-                )
-                : await parseJsonMapInIsolate(
-                  stringData,
-                  UserApiModel.fromJson,
-                );
-        return Result.ok(user);
-      } else {
-        return Result.error(Exception('Invalid response'));
-      }
-    } on Exception catch (error) {
-      return Result.error(error);
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<Result<void>> deleteBooking(int id) async {
-    final client = _clientFactory();
-    try {
-      final uri = Uri.http('$_host:$_port', '/booking/$id');
-      final response = await client.delete(uri, headers: _authHeader());
-      if (response.statusCode == 204) {
+      final response = await requestFn(client);
+      if (response.statusCode == expectedStatus) {
         return const Result.ok(null);
       } else {
         return Result.error(Exception('Invalid response'));
@@ -241,5 +77,121 @@ class ApiClient {
     } finally {
       client.close();
     }
+  }
+
+  Future<Result<List<Continent>>> getContinents() async {
+    return _send(
+      (client) => client.get(
+        Uri.http('$_host:$_port', '/continent'),
+        headers: _authHeader(),
+      ),
+      (body) async => kIsWeb
+          ? (jsonDecode(body) as List)
+              .map((e) => Continent.fromJson(e))
+              .toList()
+          : await parseJsonListInIsolate(body, Continent.fromJson),
+      200,
+    );
+  }
+
+  Future<Result<List<Destination>>> getDestinations() async {
+    return _send(
+      (client) => client.get(
+        Uri.http('$_host:$_port', '/destination'),
+        headers: _authHeader(),
+      ),
+      (body) async => kIsWeb
+          ? (jsonDecode(body) as List)
+              .map((e) => Destination.fromJson(e))
+              .toList()
+          : await parseJsonListInIsolate(body, Destination.fromJson),
+      200,
+    );
+  }
+
+  Future<Result<List<Activity>>> getActivityByDestination(String ref) async {
+    return _send(
+      (client) => client.get(
+        Uri.http('$_host:$_port', '/destination/$ref/activity'),
+        headers: _authHeader(),
+      ),
+      (body) async => kIsWeb
+          ? (jsonDecode(body) as List)
+              .map((e) => Activity.fromJson(e))
+              .toList()
+          : await parseJsonListInIsolate(body, Activity.fromJson),
+      200,
+    );
+  }
+
+  Future<Result<List<BookingApiModel>>> getBookings() async {
+    return _send(
+      (client) => client.get(
+        Uri.http('$_host:$_port', '/booking'),
+        headers: _authHeader(),
+      ),
+      (body) async => kIsWeb
+          ? (jsonDecode(body) as List)
+              .map((e) => BookingApiModel.fromJson(e))
+              .toList()
+          : await parseJsonListInIsolate(body, BookingApiModel.fromJson),
+      200,
+    );
+  }
+
+  Future<Result<BookingApiModel>> getBooking(int id) async {
+    return _send(
+      (client) => client.get(
+        Uri.http('$_host:$_port', '/booking/$id'),
+        headers: _authHeader(),
+      ),
+      (body) async => kIsWeb
+          ? BookingApiModel.fromJson(
+              jsonDecode(body) as Map<String, dynamic>,
+            )
+          : await parseJsonMapInIsolate(body, BookingApiModel.fromJson),
+      200,
+    );
+  }
+
+  Future<Result<BookingApiModel>> postBooking(BookingApiModel booking) async {
+    return _send(
+      (client) => client.post(
+        Uri.http('$_host:$_port', '/booking'),
+        headers: {..._authHeader(), 'Content-Type': 'application/json'},
+        body: jsonEncode(booking),
+      ),
+      (body) async => kIsWeb
+          ? BookingApiModel.fromJson(
+              jsonDecode(body) as Map<String, dynamic>,
+            )
+          : await parseJsonMapInIsolate(body, BookingApiModel.fromJson),
+      201,
+    );
+  }
+
+  Future<Result<UserApiModel>> getUser() async {
+    return _send(
+      (client) => client.get(
+        Uri.http('$_host:$_port', '/user'),
+        headers: _authHeader(),
+      ),
+      (body) async => kIsWeb
+          ? UserApiModel.fromJson(
+              jsonDecode(body) as Map<String, dynamic>,
+            )
+          : await parseJsonMapInIsolate(body, UserApiModel.fromJson),
+      200,
+    );
+  }
+
+  Future<Result<void>> deleteBooking(int id) async {
+    return _sendVoid(
+      (client) => client.delete(
+        Uri.http('$_host:$_port', '/booking/$id'),
+        headers: _authHeader(),
+      ),
+      204,
+    );
   }
 }

--- a/app/lib/data/services/api/auth_api_client.dart
+++ b/app/lib/data/services/api/auth_api_client.dart
@@ -23,17 +23,16 @@ class AuthApiClient {
   final int _port;
   final http.Client Function() _clientFactory;
 
-  Future<Result<LoginResponse>> login(LoginRequest loginRequest) async {
+  Future<Result<T>> _send<T>(
+    Future<http.Response> Function(http.Client) requestFn,
+    T Function(String body) parse,
+    int expectedStatus,
+  ) async {
     final client = _clientFactory();
     try {
-      final uri = Uri.http('$_host:$_port', '/login');
-      final response = await client.post(
-        uri,
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode(loginRequest),
-      );
-      if (response.statusCode == 200) {
-        return Result.ok(LoginResponse.fromJson(jsonDecode(response.body)));
+      final response = await requestFn(client);
+      if (response.statusCode == expectedStatus) {
+        return Result.ok(parse(response.body));
       } else {
         return Result.error(Exception('Login error'));
       }
@@ -42,5 +41,17 @@ class AuthApiClient {
     } finally {
       client.close();
     }
+  }
+
+  Future<Result<LoginResponse>> login(LoginRequest loginRequest) async {
+    return _send(
+      (client) => client.post(
+        Uri.http('$_host:$_port', '/login'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(loginRequest),
+      ),
+      (body) => LoginResponse.fromJson(jsonDecode(body)),
+      200,
+    );
   }
 }

--- a/server/lib/routes/booking.dart
+++ b/server/lib/routes/booking.dart
@@ -7,6 +7,8 @@ import 'dart:convert';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
+import '../utils/response_utils.dart';
+
 import '../config/assets.dart';
 import '../model/booking/booking.dart';
 
@@ -51,10 +53,7 @@ class BookingApi {
 
     // Get User bookings
     router.get('/', (Request request) {
-      return Response.ok(
-        json.encode(_bookings),
-        headers: {'Content-Type': 'application/json'},
-      );
+      return jsonResponse(_bookings);
     });
 
     // Get a booking by id
@@ -67,10 +66,7 @@ class BookingApi {
         return Response.notFound('Invalid id');
       }
 
-      return Response.ok(
-        json.encode(booking),
-        headers: {'Content-Type': 'application/json'},
-      );
+      return jsonResponse(booking);
     });
 
     // Save a new booking
@@ -92,11 +88,7 @@ class BookingApi {
       _bookings.add(bookingWithId);
 
       // Respond with newly created booking
-      return Response(
-        201, // created
-        body: json.encode(bookingWithId),
-        headers: {'Content-Type': 'application/json'},
-      );
+      return jsonResponse(bookingWithId, statusCode: 201);
     });
 
     // Delete booking

--- a/server/lib/routes/continent.dart
+++ b/server/lib/routes/continent.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:shelf/shelf.dart';
+
+import '../utils/response_utils.dart';
 
 import '../model/continent/continent.dart';
 
@@ -40,5 +40,5 @@ final _continents = [
 ];
 
 Response continentHandler(Request req) {
-  return Response.ok(jsonEncode(_continents));
+  return jsonResponse(_continents);
 }

--- a/server/lib/routes/destination.dart
+++ b/server/lib/routes/destination.dart
@@ -2,22 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
 import '../config/assets.dart';
+import '../utils/response_utils.dart';
 
 class DestinationApi {
   Router get router {
     final router = Router();
 
     router.get('/', (Request request) {
-      return Response.ok(
-        json.encode(Assets.destinations),
-        headers: {'Content-Type': 'application/json'},
-      );
+      return jsonResponse(Assets.destinations);
     });
 
     router.get('/<id>/activity', (Request request, String id) {
@@ -25,10 +21,7 @@ class DestinationApi {
           Assets.activities
               .where((activity) => activity.destinationRef == id)
               .toList();
-      return Response.ok(
-        json.encode(list),
-        headers: {'Content-Type': 'application/json'},
-      );
+      return jsonResponse(list);
     });
 
     return router;

--- a/server/lib/routes/login.dart
+++ b/server/lib/routes/login.dart
@@ -7,6 +7,8 @@ import 'dart:convert';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
+import '../utils/response_utils.dart';
+
 import '../config/constants.dart';
 import '../model/login_request/login_request.dart';
 import '../model/login_response/login_response.dart';
@@ -31,11 +33,8 @@ class LoginApi {
 
       if (loginRequest.email == Constants.email &&
           loginRequest.password == Constants.password) {
-        return Response.ok(
-          json.encode(
-            LoginResponse(token: Constants.token, userId: Constants.userId),
-          ),
-          headers: {'Content-Type': 'application/json'},
+        return jsonResponse(
+          LoginResponse(token: Constants.token, userId: Constants.userId),
         );
       }
 

--- a/server/lib/routes/user.dart
+++ b/server/lib/routes/user.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
+
+import '../utils/response_utils.dart';
 
 import '../config/constants.dart';
 
@@ -17,10 +17,7 @@ class UserApi {
     final router = Router();
 
     router.get('/', (Request request) async {
-      return Response.ok(
-        json.encode(Constants.user),
-        headers: {'Content-Type': 'application/json'},
-      );
+      return jsonResponse(Constants.user);
     });
 
     return router;

--- a/server/lib/utils/response_utils.dart
+++ b/server/lib/utils/response_utils.dart
@@ -1,0 +1,13 @@
+import 'dart:convert';
+
+import 'package:shelf/shelf.dart';
+
+/// Helper to create JSON [Response] objects with a consistent header.
+Response jsonResponse(Object body, {int statusCode = 200}) {
+  return Response(
+    statusCode,
+    body: json.encode(body),
+    headers: const {'Content-Type': 'application/json'},
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `jsonResponse` helper for consistent server responses
- simplify API client classes with shared request helpers
- update routes to use the new JSON response utility

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe58990308322bcde3020b9ccafe5