### PR TITLE
Migrate to Riverpod state management

### DIFF
--- a/app/integration_test/helpers.dart
+++ b/app/integration_test/helpers.dart
@@ -7,7 +7,7 @@ import 'package:compass_app/ui/core/ui/scroll_behavior.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../testing/fakes/repositories/fake_auth_repository.dart';
 
@@ -20,19 +20,26 @@ final stringProviders = <Locale, AppStrings>{
 
 Future<void> pumpMainAppWithLocale(WidgetTester tester, Locale locale) async {
   await tester.pumpWidget(
-    MultiProvider(
-      providers: providersLocal,
-      child: MaterialApp.router(
-        locale: locale,
-        localizationsDelegates: [
-          ...GlobalMaterialLocalizations.delegates,
-          AppLocalizationDelegate(),
-        ],
-        supportedLocales: const [Locale('en', 'US'), Locale('pt', 'BR')],
-        scrollBehavior: AppCustomScrollBehavior(),
-        theme: AppTheme.lightTheme,
-        darkTheme: AppTheme.darkTheme,
-        routerConfig: router(FakeAuthRepository()),
+    ProviderScope(
+      overrides: [
+        ...providersLocal,
+        authRepositoryProvider.overrideWith(
+          (ref) => FakeAuthRepository(),
+        ),
+      ],
+      child: Consumer(
+        builder: (context, ref, _) => MaterialApp.router(
+          locale: locale,
+          localizationsDelegates: [
+            ...GlobalMaterialLocalizations.delegates,
+            AppLocalizationDelegate(),
+          ],
+          supportedLocales: const [Locale('en', 'US'), Locale('pt', 'BR')],
+          scrollBehavior: AppCustomScrollBehavior(),
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          routerConfig: ref.watch(routerProvider),
+        ),
       ),
     ),
   );

--- a/app/integration_test/helpers.dart
+++ b/app/integration_test/helpers.dart
@@ -7,7 +7,7 @@ import 'package:compass_app/ui/core/ui/scroll_behavior.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../testing/fakes/repositories/fake_auth_repository.dart';
 

--- a/app/lib/config/dependencies.dart
+++ b/app/lib/config/dependencies.dart
@@ -28,119 +28,92 @@ import 'package:compass_app/data/services/local/local_data_service.dart';
 import 'package:compass_app/data/services/shared_preferences_service.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_create_use_case.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_share_use_case.dart';
-import 'package:provider/provider.dart';
-import 'package:provider/single_child_widget.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Shared providers for all configurations.
-List<SingleChildWidget> _sharedProviders = [
-  Provider(
-    lazy: true,
-    create:
-        (context) => BookingCreateUseCase(
-          destinationRepository: context.read(),
-          activityRepository: context.read(),
-          bookingRepository: context.read(),
-        ),
+/// API client for authentication requests.
+final authApiClientProvider = Provider((ref) => AuthApiClient());
+
+/// Generic API client.
+final apiClientProvider = Provider((ref) => ApiClient());
+
+/// Shared preferences service used to store tokens.
+final sharedPreferencesServiceProvider =
+    Provider((ref) => SharedPreferencesService());
+
+/// Local data service used only in development.
+final localDataServiceProvider = Provider((ref) => LocalDataService());
+
+/// Authentication repository used by the router to check login state.
+final authRepositoryProvider = ChangeNotifierProvider<AuthRepository>((ref) {
+  return AuthRepositoryRemote(
+    apiClient: ref.read(apiClientProvider),
+    authApiClient: ref.read(authApiClientProvider),
+    sharedPreferencesService: ref.read(sharedPreferencesServiceProvider),
+  );
+});
+
+/// Destination repository implementation.
+final destinationRepositoryProvider = Provider<DestinationRepository>((ref) {
+  return DestinationRepositoryRemote(apiClient: ref.read(apiClientProvider));
+});
+
+/// Continent repository implementation.
+final continentRepositoryProvider = Provider<ContinentRepository>((ref) {
+  return ContinentRepositoryRemote(apiClient: ref.read(apiClientProvider));
+});
+
+/// Activity repository implementation.
+final activityRepositoryProvider = Provider<ActivityRepository>((ref) {
+  return ActivityRepositoryRemote(apiClient: ref.read(apiClientProvider));
+});
+
+/// Itinerary configuration repository stored in memory.
+final itineraryConfigRepositoryProvider =
+    Provider<ItineraryConfigRepository>((ref) => ItineraryConfigRepositoryMemory());
+
+/// Booking repository implementation.
+final bookingRepositoryProvider = Provider<BookingRepository>((ref) {
+  return BookingRepositoryRemote(apiClient: ref.read(apiClientProvider));
+});
+
+/// User repository implementation.
+final userRepositoryProvider = Provider<UserRepository>((ref) {
+  return UserRepositoryRemote(apiClient: ref.read(apiClientProvider));
+});
+
+/// Use case to create a booking.
+final bookingCreateUseCaseProvider = Provider((ref) => BookingCreateUseCase(
+      destinationRepository: ref.read(destinationRepositoryProvider),
+      activityRepository: ref.read(activityRepositoryProvider),
+      bookingRepository: ref.read(bookingRepositoryProvider),
+    ));
+
+/// Use case to share a booking.
+final bookingShareUseCaseProvider =
+    Provider((ref) => BookingShareUseCase.withSharePlus());
+
+/// Overrides for local (development) configuration.
+final providersLocal = <Override>[
+  authRepositoryProvider.overrideWith((ref) => AuthRepositoryDev()),
+  destinationRepositoryProvider.overrideWith((ref) =>
+      DestinationRepositoryLocal(localDataService: ref.read(localDataServiceProvider))),
+  continentRepositoryProvider.overrideWith((ref) =>
+      ContinentRepositoryLocal(localDataService: ref.read(localDataServiceProvider))),
+  activityRepositoryProvider.overrideWith((ref) =>
+      ActivityRepositoryLocal(localDataService: ref.read(localDataServiceProvider))),
+  bookingRepositoryProvider.overrideWith((ref) =>
+      BookingRepositoryLocal(localDataService: ref.read(localDataServiceProvider))),
+  userRepositoryProvider.overrideWith((ref) =>
+      UserRepositoryLocal(localDataService: ref.read(localDataServiceProvider))),
+  itineraryConfigRepositoryProvider.overrideWithValue(
+    ItineraryConfigRepositoryMemory(),
   ),
-  Provider(
-    lazy: true,
-    create: (context) => BookingShareUseCase.withSharePlus(),
-  ),
+  localDataServiceProvider.overrideWithValue(LocalDataService()),
 ];
 
-/// Configure dependencies for remote data.
-/// This dependency list uses repositories that connect to a remote server.
-List<SingleChildWidget> get providersRemote {
-  return [
-    Provider(create: (context) => AuthApiClient()),
-    Provider(create: (context) => ApiClient()),
-    Provider(create: (context) => SharedPreferencesService()),
-    ChangeNotifierProvider(
-      create:
-          (context) =>
-              AuthRepositoryRemote(
-                    authApiClient: context.read(),
-                    apiClient: context.read(),
-                    sharedPreferencesService: context.read(),
-                  )
-                  as AuthRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              DestinationRepositoryRemote(apiClient: context.read())
-                  as DestinationRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              ContinentRepositoryRemote(apiClient: context.read())
-                  as ContinentRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              ActivityRepositoryRemote(apiClient: context.read())
-                  as ActivityRepository,
-    ),
-    Provider.value(
-      value: ItineraryConfigRepositoryMemory() as ItineraryConfigRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              BookingRepositoryRemote(apiClient: context.read())
-                  as BookingRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              UserRepositoryRemote(apiClient: context.read()) as UserRepository,
-    ),
-    ..._sharedProviders,
-  ];
-}
-
-/// Configure dependencies for local data.
-/// This dependency list uses repositories that provide local data.
-/// The user is always logged in.
-List<SingleChildWidget> get providersLocal {
-  return [
-    ChangeNotifierProvider.value(value: AuthRepositoryDev() as AuthRepository),
-    Provider.value(value: LocalDataService()),
-    Provider(
-      create:
-          (context) =>
-              DestinationRepositoryLocal(localDataService: context.read())
-                  as DestinationRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              ContinentRepositoryLocal(localDataService: context.read())
-                  as ContinentRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              ActivityRepositoryLocal(localDataService: context.read())
-                  as ActivityRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              BookingRepositoryLocal(localDataService: context.read())
-                  as BookingRepository,
-    ),
-    Provider.value(
-      value: ItineraryConfigRepositoryMemory() as ItineraryConfigRepository,
-    ),
-    Provider(
-      create:
-          (context) =>
-              UserRepositoryLocal(localDataService: context.read())
-                  as UserRepository,
-    ),
-    ..._sharedProviders,
-  ];
-}
+/// Overrides for remote (staging) configuration. Empty because remote is default.
+final providersRemote = <Override>[
+  itineraryConfigRepositoryProvider.overrideWithValue(
+    ItineraryConfigRepositoryMemory(),
+  ),
+];

--- a/app/lib/config/dependencies.dart
+++ b/app/lib/config/dependencies.dart
@@ -28,7 +28,7 @@ import 'package:compass_app/data/services/local/local_data_service.dart';
 import 'package:compass_app/data/services/shared_preferences_service.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_create_use_case.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_share_use_case.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// API client for authentication requests.
 final authApiClientProvider = Provider((ref) => AuthApiClient());

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:compass_app/ui/core/themes/theme.dart';
 import 'package:compass_app/ui/core/ui/scroll_behavior.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Default main method
 void main() {
@@ -17,11 +17,11 @@ void main() {
   development.main();
 }
 
-class MainApp extends StatelessWidget {
+class MainApp extends ConsumerWidget {
   const MainApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return MaterialApp.router(
       localizationsDelegates: [
         ...GlobalMaterialLocalizations.delegates,
@@ -33,7 +33,7 @@ class MainApp extends StatelessWidget {
       scrollBehavior: AppCustomScrollBehavior(),
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
-      routerConfig: router(context.read()),
+      routerConfig: ref.watch(routerProvider),
     );
   }
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:compass_app/ui/core/themes/theme.dart';
 import 'package:compass_app/ui/core/ui/scroll_behavior.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Default main method
 void main() {
@@ -17,7 +17,7 @@ void main() {
   development.main();
 }
 
-class MainApp extends ConsumerWidget {
+class MainApp extends HookConsumerWidget {
   const MainApp({super.key});
 
   @override

--- a/app/lib/main_development.dart
+++ b/app/lib/main_development.dart
@@ -6,7 +6,7 @@ import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/main.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Development config entry point.
 /// Launch with `flutter run --target lib/main_development.dart`.
@@ -14,5 +14,5 @@ import 'package:provider/provider.dart';
 void main() {
   Logger.root.level = Level.ALL;
 
-  runApp(MultiProvider(providers: providersLocal, child: const MainApp()));
+  runApp(ProviderScope(overrides: providersLocal, child: const MainApp()));
 }

--- a/app/lib/main_development.dart
+++ b/app/lib/main_development.dart
@@ -6,7 +6,7 @@ import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/main.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Development config entry point.
 /// Launch with `flutter run --target lib/main_development.dart`.

--- a/app/lib/main_staging.dart
+++ b/app/lib/main_staging.dart
@@ -6,7 +6,7 @@ import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/main.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Staging config entry point.
 /// Launch with `flutter run --target lib/main_staging.dart`.

--- a/app/lib/main_staging.dart
+++ b/app/lib/main_staging.dart
@@ -6,7 +6,7 @@ import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/main.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Staging config entry point.
 /// Launch with `flutter run --target lib/main_staging.dart`.
@@ -14,5 +14,5 @@ import 'package:provider/provider.dart';
 void main() {
   Logger.root.level = Level.ALL;
 
-  runApp(MultiProvider(providers: providersRemote, child: const MainApp()));
+  runApp(ProviderScope(overrides: providersRemote, child: const MainApp()));
 }

--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -18,22 +18,27 @@ import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dar
 import 'package:compass_app/ui/search_form/widgets/search_form_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Top go_router entry point.
 ///
 /// Listens to changes in [AuthTokenRepository] to redirect the user
 /// to /login when the user logs out.
-GoRouter router(AuthRepository authRepository) => GoRouter(
-  initialLocation: Routes.home,
-  debugLogDiagnostics: true,
-  redirect: _redirect,
-  refreshListenable: authRepository,
-  routes: [
+typedef Reader = T Function<T>(ProviderListenable<T> provider);
+
+final routerProvider = Provider<GoRouter>((ref) {
+  final authRepository = ref.watch(authRepositoryProvider);
+  return GoRouter(
+    initialLocation: Routes.home,
+    debugLogDiagnostics: true,
+    redirect: (context, state) => _redirect(context, state, ref.read),
+    refreshListenable: authRepository,
+    routes: [
     GoRoute(
       path: Routes.login,
       builder: (context, state) {
-        final viewModel = LoginViewModel(authRepository: context.read());
+        final viewModel =
+            LoginViewModel(authRepository: context.read(authRepositoryProvider));
         return LoginScreen(viewModel: viewModel);
       },
     ),
@@ -41,8 +46,8 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
       path: Routes.home,
       builder: (context, state) {
         final viewModel = HomeViewModel(
-          bookingRepository: context.read(),
-          userRepository: context.read(),
+          bookingRepository: context.read(bookingRepositoryProvider),
+          userRepository: context.read(userRepositoryProvider),
         );
         return HomeScreen(viewModel: viewModel);
       },
@@ -51,8 +56,9 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
           path: Routes.searchRelative,
           builder: (context, state) {
             final viewModel = SearchFormViewModel(
-              continentRepository: context.read(),
-              itineraryConfigRepository: context.read(),
+              continentRepository: context.read(continentRepositoryProvider),
+              itineraryConfigRepository:
+                  context.read(itineraryConfigRepositoryProvider),
             );
             return SearchFormScreen(viewModel: viewModel);
           },
@@ -61,8 +67,9 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
           path: Routes.resultsRelative,
           builder: (context, state) {
             final viewModel = ResultsViewModel(
-              destinationRepository: context.read(),
-              itineraryConfigRepository: context.read(),
+              destinationRepository: context.read(destinationRepositoryProvider),
+              itineraryConfigRepository:
+                  context.read(itineraryConfigRepositoryProvider),
             );
             return ResultsScreen(viewModel: viewModel);
           },
@@ -71,8 +78,9 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
           path: Routes.activitiesRelative,
           builder: (context, state) {
             final viewModel = ActivitiesViewModel(
-              activityRepository: context.read(),
-              itineraryConfigRepository: context.read(),
+              activityRepository: context.read(activityRepositoryProvider),
+              itineraryConfigRepository:
+                  context.read(itineraryConfigRepositoryProvider),
             );
             return ActivitiesScreen(viewModel: viewModel);
           },
@@ -81,10 +89,13 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
           path: Routes.bookingRelative,
           builder: (context, state) {
             final viewModel = BookingViewModel(
-              itineraryConfigRepository: context.read(),
-              createBookingUseCase: context.read(),
-              shareBookingUseCase: context.read(),
-              bookingRepository: context.read(),
+              itineraryConfigRepository:
+                  context.read(itineraryConfigRepositoryProvider),
+              createBookingUseCase:
+                  context.read(bookingCreateUseCaseProvider),
+              shareBookingUseCase:
+                  context.read(bookingShareUseCaseProvider),
+              bookingRepository: context.read(bookingRepositoryProvider),
             );
 
             // When opening the booking screen directly
@@ -99,10 +110,13 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
               builder: (context, state) {
                 final id = int.parse(state.pathParameters['id']!);
                 final viewModel = BookingViewModel(
-                  itineraryConfigRepository: context.read(),
-                  createBookingUseCase: context.read(),
-                  shareBookingUseCase: context.read(),
-                  bookingRepository: context.read(),
+                  itineraryConfigRepository:
+                      context.read(itineraryConfigRepositoryProvider),
+                  createBookingUseCase:
+                      context.read(bookingCreateUseCaseProvider),
+                  shareBookingUseCase:
+                      context.read(bookingShareUseCaseProvider),
+                  bookingRepository: context.read(bookingRepositoryProvider),
                 );
 
                 // When opening the booking screen with an existing id
@@ -117,12 +131,17 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
       ],
     ),
   ],
-);
+  );
+});
 
 // From https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/redirection.dart
-Future<String?> _redirect(BuildContext context, GoRouterState state) async {
+Future<String?> _redirect(
+  BuildContext context,
+  GoRouterState state,
+  Reader read,
+) async {
   // if the user is not logged in, they need to login
-  final loggedIn = await context.read<AuthRepository>().isAuthenticated;
+  final loggedIn = await read(authRepositoryProvider).isAuthenticated;
   final loggingIn = state.matchedLocation == Routes.login;
   if (!loggedIn) {
     return Routes.login;

--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:compass_app/data/repositories/auth/auth_repository.dart';
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/routing/routes.dart';
 import 'package:compass_app/ui/activities/view_models/activities_viewmodel.dart';
 import 'package:compass_app/ui/activities/widgets/activities_screen.dart';
@@ -34,131 +34,141 @@ final routerProvider = Provider<GoRouter>((ref) {
     redirect: (context, state) => _redirect(context, state, ref.read),
     refreshListenable: authRepository,
     routes: [
-    GoRoute(
-      path: Routes.login,
-      builder: (context, state) {
-        return Consumer(
-          builder: (context, ref, _) {
-            final viewModel =
-                LoginViewModel(authRepository: ref.read(authRepositoryProvider));
-            return LoginScreen(viewModel: viewModel);
-          },
-        );
-      },
-    ),
-    GoRoute(
-      path: Routes.home,
-      builder: (context, state) {
-        return Consumer(
-          builder: (context, ref, _) {
-            final viewModel = HomeViewModel(
-              bookingRepository: ref.read(bookingRepositoryProvider),
-              userRepository: ref.read(userRepositoryProvider),
-            );
-            return HomeScreen(viewModel: viewModel);
-          },
-        );
-      },
-      routes: [
-        GoRoute(
-          path: Routes.searchRelative,
-          builder: (context, state) {
-            return Consumer(
-              builder: (context, ref, _) {
-                final viewModel = SearchFormViewModel(
-                  continentRepository: ref.read(continentRepositoryProvider),
-                  itineraryConfigRepository:
-                      ref.read(itineraryConfigRepositoryProvider),
-                );
-                return SearchFormScreen(viewModel: viewModel);
-              },
-            );
-          },
-        ),
-        GoRoute(
-          path: Routes.resultsRelative,
-          builder: (context, state) {
-            return Consumer(
-              builder: (context, ref, _) {
-                final viewModel = ResultsViewModel(
-                  destinationRepository: ref.read(destinationRepositoryProvider),
-                  itineraryConfigRepository:
-                      ref.read(itineraryConfigRepositoryProvider),
-                );
-                return ResultsScreen(viewModel: viewModel);
-              },
-            );
-          },
-        ),
-        GoRoute(
-          path: Routes.activitiesRelative,
-          builder: (context, state) {
-            return Consumer(
-              builder: (context, ref, _) {
-                final viewModel = ActivitiesViewModel(
-                  activityRepository: ref.read(activityRepositoryProvider),
-                  itineraryConfigRepository:
-                      ref.read(itineraryConfigRepositoryProvider),
-                );
-                return ActivitiesScreen(viewModel: viewModel);
-              },
-            );
-          },
-        ),
-        GoRoute(
-          path: Routes.bookingRelative,
-          builder: (context, state) {
-            return Consumer(
-              builder: (context, ref, _) {
-                final viewModel = BookingViewModel(
-                  itineraryConfigRepository:
-                      ref.read(itineraryConfigRepositoryProvider),
-                  createBookingUseCase:
-                      ref.read(bookingCreateUseCaseProvider),
-                  shareBookingUseCase:
-                      ref.read(bookingShareUseCaseProvider),
-                  bookingRepository: ref.read(bookingRepositoryProvider),
-                );
+      GoRoute(
+        path: Routes.login,
+        builder: (context, state) {
+          return Consumer(
+            builder: (context, ref, _) {
+              final viewModel = LoginViewModel(
+                authRepository: ref.read(authRepositoryProvider),
+              );
+              return LoginScreen(viewModel: viewModel);
+            },
+          );
+        },
+      ),
+      GoRoute(
+        path: Routes.home,
+        builder: (context, state) {
+          return Consumer(
+            builder: (context, ref, _) {
+              final viewModel = HomeViewModel(
+                bookingRepository: ref.read(bookingRepositoryProvider),
+                userRepository: ref.read(userRepositoryProvider),
+              );
+              return HomeScreen(viewModel: viewModel);
+            },
+          );
+        },
+        routes: [
+          GoRoute(
+            path: Routes.searchRelative,
+            builder: (context, state) {
+              return Consumer(
+                builder: (context, ref, _) {
+                  final viewModel = SearchFormViewModel(
+                    continentRepository: ref.read(continentRepositoryProvider),
+                    itineraryConfigRepository: ref.read(
+                      itineraryConfigRepositoryProvider,
+                    ),
+                  );
+                  return SearchFormScreen(viewModel: viewModel);
+                },
+              );
+            },
+          ),
+          GoRoute(
+            path: Routes.resultsRelative,
+            builder: (context, state) {
+              return Consumer(
+                builder: (context, ref, _) {
+                  final viewModel = ResultsViewModel(
+                    destinationRepository: ref.read(
+                      destinationRepositoryProvider,
+                    ),
+                    itineraryConfigRepository: ref.read(
+                      itineraryConfigRepositoryProvider,
+                    ),
+                  );
+                  return ResultsScreen(viewModel: viewModel);
+                },
+              );
+            },
+          ),
+          GoRoute(
+            path: Routes.activitiesRelative,
+            builder: (context, state) {
+              return Consumer(
+                builder: (context, ref, _) {
+                  final viewModel = ActivitiesViewModel(
+                    activityRepository: ref.read(activityRepositoryProvider),
+                    itineraryConfigRepository: ref.read(
+                      itineraryConfigRepositoryProvider,
+                    ),
+                  );
+                  return ActivitiesScreen(viewModel: viewModel);
+                },
+              );
+            },
+          ),
+          GoRoute(
+            path: Routes.bookingRelative,
+            builder: (context, state) {
+              return Consumer(
+                builder: (context, ref, _) {
+                  final viewModel = BookingViewModel(
+                    itineraryConfigRepository: ref.read(
+                      itineraryConfigRepositoryProvider,
+                    ),
+                    createBookingUseCase: ref.read(
+                      bookingCreateUseCaseProvider,
+                    ),
+                    shareBookingUseCase: ref.read(bookingShareUseCaseProvider),
+                    bookingRepository: ref.read(bookingRepositoryProvider),
+                  );
 
-                // When opening the booking screen directly
-                // create a new booking from the stored ItineraryConfig.
-                viewModel.createBooking.execute();
+                  // When opening the booking screen directly
+                  // create a new booking from the stored ItineraryConfig.
+                  viewModel.createBooking.execute();
 
-                return BookingScreen(viewModel: viewModel);
-              },
-            );
-          },
-          routes: [
-            GoRoute(
-              path: ':id',
-              builder: (context, state) {
-                final id = int.parse(state.pathParameters['id']!);
-                return Consumer(
-                  builder: (context, ref, _) {
-                    final viewModel = BookingViewModel(
-                      itineraryConfigRepository:
-                          ref.read(itineraryConfigRepositoryProvider),
-                      createBookingUseCase:
-                          ref.read(bookingCreateUseCaseProvider),
-                      shareBookingUseCase:
-                          ref.read(bookingShareUseCaseProvider),
-                      bookingRepository: ref.read(bookingRepositoryProvider),
-                    );
+                  return BookingScreen(viewModel: viewModel);
+                },
+              );
+            },
+            routes: [
+              GoRoute(
+                path: ':id',
+                builder: (context, state) {
+                  final id = int.parse(state.pathParameters['id']!);
+                  return Consumer(
+                    builder: (context, ref, _) {
+                      final viewModel = BookingViewModel(
+                        itineraryConfigRepository: ref.read(
+                          itineraryConfigRepositoryProvider,
+                        ),
+                        createBookingUseCase: ref.read(
+                          bookingCreateUseCaseProvider,
+                        ),
+                        shareBookingUseCase: ref.read(
+                          bookingShareUseCaseProvider,
+                        ),
+                        bookingRepository: ref.read(bookingRepositoryProvider),
+                      );
 
-                    // When opening the booking screen with an existing id
-                    // load and display that booking.
-                    viewModel.loadBooking.execute(id);
+                      // When opening the booking screen with an existing id
+                      // load and display that booking.
+                      viewModel.loadBooking.execute(id);
 
-                    return BookingScreen(viewModel: viewModel);
-                  },
-                );
-              },
-            ),
-          ],
-        ),
-      ],
-    ),
-  ],
+                      return BookingScreen(viewModel: viewModel);
+                    },
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
   );
 });
 

--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -18,7 +18,7 @@ import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dar
 import 'package:compass_app/ui/search_form/widgets/search_form_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Top go_router entry point.
 ///

--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -37,93 +37,121 @@ final routerProvider = Provider<GoRouter>((ref) {
     GoRoute(
       path: Routes.login,
       builder: (context, state) {
-        final viewModel =
-            LoginViewModel(authRepository: context.read(authRepositoryProvider));
-        return LoginScreen(viewModel: viewModel);
+        return Consumer(
+          builder: (context, ref, _) {
+            final viewModel =
+                LoginViewModel(authRepository: ref.read(authRepositoryProvider));
+            return LoginScreen(viewModel: viewModel);
+          },
+        );
       },
     ),
     GoRoute(
       path: Routes.home,
       builder: (context, state) {
-        final viewModel = HomeViewModel(
-          bookingRepository: context.read(bookingRepositoryProvider),
-          userRepository: context.read(userRepositoryProvider),
+        return Consumer(
+          builder: (context, ref, _) {
+            final viewModel = HomeViewModel(
+              bookingRepository: ref.read(bookingRepositoryProvider),
+              userRepository: ref.read(userRepositoryProvider),
+            );
+            return HomeScreen(viewModel: viewModel);
+          },
         );
-        return HomeScreen(viewModel: viewModel);
       },
       routes: [
         GoRoute(
           path: Routes.searchRelative,
           builder: (context, state) {
-            final viewModel = SearchFormViewModel(
-              continentRepository: context.read(continentRepositoryProvider),
-              itineraryConfigRepository:
-                  context.read(itineraryConfigRepositoryProvider),
+            return Consumer(
+              builder: (context, ref, _) {
+                final viewModel = SearchFormViewModel(
+                  continentRepository: ref.read(continentRepositoryProvider),
+                  itineraryConfigRepository:
+                      ref.read(itineraryConfigRepositoryProvider),
+                );
+                return SearchFormScreen(viewModel: viewModel);
+              },
             );
-            return SearchFormScreen(viewModel: viewModel);
           },
         ),
         GoRoute(
           path: Routes.resultsRelative,
           builder: (context, state) {
-            final viewModel = ResultsViewModel(
-              destinationRepository: context.read(destinationRepositoryProvider),
-              itineraryConfigRepository:
-                  context.read(itineraryConfigRepositoryProvider),
+            return Consumer(
+              builder: (context, ref, _) {
+                final viewModel = ResultsViewModel(
+                  destinationRepository: ref.read(destinationRepositoryProvider),
+                  itineraryConfigRepository:
+                      ref.read(itineraryConfigRepositoryProvider),
+                );
+                return ResultsScreen(viewModel: viewModel);
+              },
             );
-            return ResultsScreen(viewModel: viewModel);
           },
         ),
         GoRoute(
           path: Routes.activitiesRelative,
           builder: (context, state) {
-            final viewModel = ActivitiesViewModel(
-              activityRepository: context.read(activityRepositoryProvider),
-              itineraryConfigRepository:
-                  context.read(itineraryConfigRepositoryProvider),
+            return Consumer(
+              builder: (context, ref, _) {
+                final viewModel = ActivitiesViewModel(
+                  activityRepository: ref.read(activityRepositoryProvider),
+                  itineraryConfigRepository:
+                      ref.read(itineraryConfigRepositoryProvider),
+                );
+                return ActivitiesScreen(viewModel: viewModel);
+              },
             );
-            return ActivitiesScreen(viewModel: viewModel);
           },
         ),
         GoRoute(
           path: Routes.bookingRelative,
           builder: (context, state) {
-            final viewModel = BookingViewModel(
-              itineraryConfigRepository:
-                  context.read(itineraryConfigRepositoryProvider),
-              createBookingUseCase:
-                  context.read(bookingCreateUseCaseProvider),
-              shareBookingUseCase:
-                  context.read(bookingShareUseCaseProvider),
-              bookingRepository: context.read(bookingRepositoryProvider),
+            return Consumer(
+              builder: (context, ref, _) {
+                final viewModel = BookingViewModel(
+                  itineraryConfigRepository:
+                      ref.read(itineraryConfigRepositoryProvider),
+                  createBookingUseCase:
+                      ref.read(bookingCreateUseCaseProvider),
+                  shareBookingUseCase:
+                      ref.read(bookingShareUseCaseProvider),
+                  bookingRepository: ref.read(bookingRepositoryProvider),
+                );
+
+                // When opening the booking screen directly
+                // create a new booking from the stored ItineraryConfig.
+                viewModel.createBooking.execute();
+
+                return BookingScreen(viewModel: viewModel);
+              },
             );
-
-            // When opening the booking screen directly
-            // create a new booking from the stored ItineraryConfig.
-            viewModel.createBooking.execute();
-
-            return BookingScreen(viewModel: viewModel);
           },
           routes: [
             GoRoute(
               path: ':id',
               builder: (context, state) {
                 final id = int.parse(state.pathParameters['id']!);
-                final viewModel = BookingViewModel(
-                  itineraryConfigRepository:
-                      context.read(itineraryConfigRepositoryProvider),
-                  createBookingUseCase:
-                      context.read(bookingCreateUseCaseProvider),
-                  shareBookingUseCase:
-                      context.read(bookingShareUseCaseProvider),
-                  bookingRepository: context.read(bookingRepositoryProvider),
+                return Consumer(
+                  builder: (context, ref, _) {
+                    final viewModel = BookingViewModel(
+                      itineraryConfigRepository:
+                          ref.read(itineraryConfigRepositoryProvider),
+                      createBookingUseCase:
+                          ref.read(bookingCreateUseCaseProvider),
+                      shareBookingUseCase:
+                          ref.read(bookingShareUseCaseProvider),
+                      bookingRepository: ref.read(bookingRepositoryProvider),
+                    );
+
+                    // When opening the booking screen with an existing id
+                    // load and display that booking.
+                    viewModel.loadBooking.execute(id);
+
+                    return BookingScreen(viewModel: viewModel);
+                  },
                 );
-
-                // When opening the booking screen with an existing id
-                // load and display that booking.
-                viewModel.loadBooking.execute(id);
-
-                return BookingScreen(viewModel: viewModel);
               },
             ),
           ],

--- a/app/lib/ui/home/widgets/home_title.dart
+++ b/app/lib/ui/home/widgets/home_title.dart
@@ -11,13 +11,13 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class HomeHeader extends StatelessWidget {
+class HomeHeader extends ConsumerWidget {
   const HomeHeader({required this.viewModel, super.key});
 
   final HomeViewModel viewModel;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final user = viewModel.user;
     if (user == null) {
       return const SizedBox();
@@ -38,9 +38,9 @@ class HomeHeader extends StatelessWidget {
             ),
             LogoutButton(
               viewModel: LogoutViewModel(
-                authRepository: context.read(authRepositoryProvider),
+                authRepository: ref.read(authRepositoryProvider),
                 itineraryConfigRepository:
-                    context.read(itineraryConfigRepositoryProvider),
+                    ref.read(itineraryConfigRepositoryProvider),
               ),
             ),
           ],

--- a/app/lib/ui/home/widgets/home_title.dart
+++ b/app/lib/ui/home/widgets/home_title.dart
@@ -9,7 +9,7 @@ import 'package:compass_app/ui/core/themes/dimens.dart';
 import 'package:compass_app/ui/home/view_models/home_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class HomeHeader extends StatelessWidget {
   const HomeHeader({required this.viewModel, super.key});
@@ -38,8 +38,9 @@ class HomeHeader extends StatelessWidget {
             ),
             LogoutButton(
               viewModel: LogoutViewModel(
-                authRepository: context.read(),
-                itineraryConfigRepository: context.read(),
+                authRepository: context.read(authRepositoryProvider),
+                itineraryConfigRepository:
+                    context.read(itineraryConfigRepositoryProvider),
               ),
             ),
           ],

--- a/app/lib/ui/home/widgets/home_title.dart
+++ b/app/lib/ui/home/widgets/home_title.dart
@@ -9,9 +9,9 @@ import 'package:compass_app/ui/core/themes/dimens.dart';
 import 'package:compass_app/ui/home/view_models/home_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class HomeHeader extends ConsumerWidget {
+class HomeHeader extends HookConsumerWidget {
   const HomeHeader({required this.viewModel, super.key});
 
   final HomeViewModel viewModel;

--- a/app/lib/ui/home/widgets/home_title.dart
+++ b/app/lib/ui/home/widgets/home_title.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/auth/logout/view_models/logout_viewmodel.dart';
 import 'package:compass_app/ui/auth/logout/widgets/logout_button.dart';
 import 'package:compass_app/ui/core/localization/applocalization.dart';
@@ -39,8 +40,9 @@ class HomeHeader extends HookConsumerWidget {
             LogoutButton(
               viewModel: LogoutViewModel(
                 authRepository: ref.read(authRepositoryProvider),
-                itineraryConfigRepository:
-                    ref.read(itineraryConfigRepositoryProvider),
+                itineraryConfigRepository: ref.read(
+                  itineraryConfigRepositoryProvider,
+                ),
               ),
             ),
           ],
@@ -61,12 +63,11 @@ class _Title extends StatelessWidget {
   Widget build(BuildContext context) {
     return ShaderMask(
       blendMode: BlendMode.srcIn,
-      shaderCallback:
-          (bounds) => RadialGradient(
-            center: Alignment.bottomLeft,
-            radius: 2,
-            colors: [Colors.purple.shade700, Colors.purple.shade400],
-          ).createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
+      shaderCallback: (bounds) => RadialGradient(
+        center: Alignment.bottomLeft,
+        radius: 2,
+        colors: [Colors.purple.shade700, Colors.purple.shade400],
+      ).createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
       child: Text(
         text,
         style: GoogleFonts.rubik(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -251,6 +251,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: transitive
+    description:
+      name: flutter_hooks
+      sha256: b772e710d16d7a20c0740c4f855095026b31c7eb5ba3ab67d2bd52021cd9461d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.21.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -264,6 +272,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_riverpod:
+    dependency: transitive
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -343,6 +359,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  hooks_riverpod:
+    dependency: "direct main"
+    description:
+      name: hooks_riverpod
+      sha256: "70bba33cfc5670c84b796e6929c54b8bc5be7d0fe15bb28c2560500b9ad06966"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   http:
     dependency: "direct main"
     description:
@@ -500,14 +524,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   octo_image:
     dependency: transitive
     description:
@@ -628,14 +644,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
-  provider:
-    dependency: "direct main"
-    description:
-      name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5"
   pub_semver:
     dependency: transitive
     description:
@@ -668,6 +676,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   rxdart:
     dependency: transitive
     description:
@@ -849,6 +865,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,8 +21,7 @@ dependencies:
   intl: any
   json_annotation: ^4.9.0
   logging: ^1.3.0
-  flutter_riverpod: ^2.6.1
-  riverpod: ^2.6.1
+  hooks_riverpod: ^2.6.1
   result_command: ^2.1.0
   result_dart: ^2.1.1
   share_plus: ^10.1.3

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,7 +21,8 @@ dependencies:
   intl: any
   json_annotation: ^4.9.0
   logging: ^1.3.0
-  provider: ^6.1.2
+  flutter_riverpod: ^2.6.1
+  riverpod: ^2.6.1
   result_command: ^2.1.0
   result_dart: ^2.1.1
   share_plus: ^10.1.3

--- a/app/test/ui/home/widgets/home_screen_test.dart
+++ b/app/test/ui/home/widgets/home_screen_test.dart
@@ -42,8 +42,9 @@ void main() {
         tester,
         ProviderScope(
           overrides: [
-            authRepositoryProvider
-                .overrideWithValue(FakeAuthRepository()),
+            authRepositoryProvider.overrideWith(
+              (ref) => FakeAuthRepository(),
+            ),
             itineraryConfigRepositoryProvider.overrideWithValue(
               FakeItineraryConfigRepository(),
             ),

--- a/app/test/ui/home/widgets/home_screen_test.dart
+++ b/app/test/ui/home/widgets/home_screen_test.dart
@@ -10,7 +10,7 @@ import 'package:compass_app/ui/home/widgets/home_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:result_dart/result_dart.dart';
 
 import '../../../../testing/app.dart';

--- a/app/test/ui/home/widgets/home_screen_test.dart
+++ b/app/test/ui/home/widgets/home_screen_test.dart
@@ -2,15 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:compass_app/data/repositories/auth/auth_repository.dart';
-import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_repository.dart';
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/routing/routes.dart';
 import 'package:compass_app/ui/home/view_models/home_viewmodel.dart';
 import 'package:compass_app/ui/home/widgets/home_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:result_dart/result_dart.dart';
 
 import '../../../../testing/app.dart';

--- a/app/test/ui/home/widgets/home_screen_test.dart
+++ b/app/test/ui/home/widgets/home_screen_test.dart
@@ -10,7 +10,7 @@ import 'package:compass_app/ui/home/widgets/home_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:result_dart/result_dart.dart';
 
 import '../../../../testing/app.dart';
@@ -40,12 +40,15 @@ void main() {
     Future<void> loadWidget(WidgetTester tester) async {
       await testApp(
         tester,
-        ChangeNotifierProvider.value(
-          value: FakeAuthRepository() as AuthRepository,
-          child: Provider.value(
-            value: FakeItineraryConfigRepository() as ItineraryConfigRepository,
-            child: HomeScreen(viewModel: viewModel),
-          ),
+        ProviderScope(
+          overrides: [
+            authRepositoryProvider
+                .overrideWithValue(FakeAuthRepository()),
+            itineraryConfigRepositoryProvider.overrideWithValue(
+              FakeItineraryConfigRepository(),
+            ),
+          ],
+          child: HomeScreen(viewModel: viewModel),
         ),
         goRouter: goRouter,
       );

--- a/app/test/ui/search_form/widgets/search_form_screen_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_screen_test.dart
@@ -37,8 +37,9 @@ void main() {
         tester,
         ProviderScope(
           overrides: [
-            authRepositoryProvider
-                .overrideWithValue(FakeAuthRepository()),
+            authRepositoryProvider.overrideWith(
+              (ref) => FakeAuthRepository(),
+            ),
             itineraryConfigRepositoryProvider.overrideWithValue(
               FakeItineraryConfigRepository(),
             ),

--- a/app/test/ui/search_form/widgets/search_form_screen_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_screen_test.dart
@@ -11,7 +11,7 @@ import 'package:compass_app/ui/search_form/widgets/search_form_submit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../testing/app.dart';
 import '../../../../testing/fakes/repositories/fake_auth_repository.dart';

--- a/app/test/ui/search_form/widgets/search_form_screen_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_screen_test.dart
@@ -11,7 +11,7 @@ import 'package:compass_app/ui/search_form/widgets/search_form_submit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../testing/app.dart';
 import '../../../../testing/fakes/repositories/fake_auth_repository.dart';
@@ -35,12 +35,15 @@ void main() {
     Future<void> loadWidget(WidgetTester tester) async {
       await testApp(
         tester,
-        ChangeNotifierProvider.value(
-          value: FakeAuthRepository() as AuthRepository,
-          child: Provider.value(
-            value: FakeItineraryConfigRepository() as ItineraryConfigRepository,
-            child: SearchFormScreen(viewModel: viewModel),
-          ),
+        ProviderScope(
+          overrides: [
+            authRepositoryProvider
+                .overrideWithValue(FakeAuthRepository()),
+            itineraryConfigRepositoryProvider.overrideWithValue(
+              FakeItineraryConfigRepository(),
+            ),
+          ],
+          child: SearchFormScreen(viewModel: viewModel),
         ),
         goRouter: goRouter,
       );

--- a/app/test/ui/search_form/widgets/search_form_screen_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_screen_test.dart
@@ -2,16 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:compass_app/data/repositories/auth/auth_repository.dart';
-import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_repository.dart';
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dart';
 import 'package:compass_app/ui/search_form/widgets/search_form_guests.dart';
 import 'package:compass_app/ui/search_form/widgets/search_form_screen.dart';
 import 'package:compass_app/ui/search_form/widgets/search_form_submit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../../../testing/app.dart';
 import '../../../../testing/fakes/repositories/fake_auth_repository.dart';

--- a/documentation/CompassApp/Prompts/Codex.md
+++ b/documentation/CompassApp/Prompts/Codex.md
@@ -1,10 +1,9 @@
 Tarefa:
 
+Requisitos para a resposta:
 
-**Requisitos para a resposta:**
-
-* Retorne o código completo implementado, incluindo o arquivo de testes.
-* O código deve ser totalmente documentado, com comentários em inglês.
-* Toda e qualquer modificação no código, nomes de variáveis, mensagens de commit, nome da branch e descrição do pull request devem estar em inglês.
-* Não traduza ou escreva nenhum trecho do código em português.
-* No chat, explique em português, de forma objetiva, o que foi implementado e como a nova lógica funciona.
+- Retorne o código completo implementado, incluindo o arquivo de testes.
+- O código deve ser totalmente documentado, com comentários em inglês.
+- Toda e qualquer modificação no código, nomes de variáveis, mensagens de commit, nome da branch e descrição do pull request devem estar em inglês.
+- Não traduza ou escreva nenhum trecho do código em português.
+- No chat, explique em português, de forma objetiva, o que foi implementado e como a nova lógica funciona.

--- a/documentation/CompassApp/Versioning.md
+++ b/documentation/CompassApp/Versioning.md
@@ -29,3 +29,8 @@
 - [x] 0.1.13; enhance the code
 - [x] 0.1.14; fix: resolve all project warnings
 - [x] 0.1.15; chore: update SDK version and dependencies across project files
+- [x] Replace Provider with Riverpod
+- [x] Fix Riverpod integration
+- [x] Fix provider overrides in tests
+- [x] Use hooks_riverpod for state management
+- [x] 0.2.4; refactor: update imports and clean up routing code for better readability


### PR DESCRIPTION
## Summary
- replace Provider with Riverpod across the application
- expose repositories and use-cases as Riverpod providers
- bootstrap the app with `ProviderScope` and watch `routerProvider`
- update router to build widgets using Riverpod
- adjust tests to override providers with `ProviderScope`

## Testing
- `flutter test` *(fails: flutter not available)*

------
https://chatgpt.com/codex/tasks/task_e_686d4a43241083229537c243b4679f15