### PR TITLE
Refactor auth and booking widgets to use hooks

### DIFF
--- a/app/lib/ui/auth/login/widgets/login_screen.dart
+++ b/app/lib/ui/auth/login/widgets/login_screen.dart
@@ -8,46 +8,48 @@ import 'package:compass_app/ui/auth/login/widgets/tilted_cards.dart';
 import 'package:compass_app/ui/core/localization/applocalization.dart';
 import 'package:compass_app/ui/core/themes/dimens.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 
-class LoginScreen extends StatefulWidget {
+class LoginScreen extends HookConsumerWidget {
   const LoginScreen({required this.viewModel, super.key});
 
   final LoginViewModel viewModel;
 
   @override
-  State<LoginScreen> createState() => _LoginScreenState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final email = useTextEditingController(text: 'email@example.com');
+    final password = useTextEditingController(text: 'password');
 
-class _LoginScreenState extends State<LoginScreen> {
-  final TextEditingController _email = TextEditingController(
-    text: 'email@example.com',
-  );
-  final TextEditingController _password = TextEditingController(
-    text: 'password',
-  );
+    void onResult() {
+      if (viewModel.login.value.isSuccess) {
+        viewModel.login.reset();
+        context.go(Routes.home);
+      }
+      if (viewModel.login.value.isFailure) {
+        viewModel.login.reset();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppLocalization.of(context).errorWhileLogin),
+            action: SnackBarAction(
+              label: AppLocalization.of(context).tryAgain,
+              onPressed: () => viewModel.login.execute((
+                email.value.text,
+                password.value.text,
+              )),
+            ),
+          ),
+        );
+      }
+    }
 
-  @override
-  void initState() {
-    super.initState();
-    widget.viewModel.login.addListener(_onResult);
-  }
+    useEffect(() {
+      viewModel.login.addListener(onResult);
+      return () => viewModel.login.removeListener(onResult);
+    }, [viewModel]);
 
-  @override
-  void didUpdateWidget(covariant LoginScreen oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    oldWidget.viewModel.login.removeListener(_onResult);
-    widget.viewModel.login.addListener(_onResult);
-  }
+    useListenable(viewModel.login);
 
-  @override
-  void dispose() {
-    widget.viewModel.login.removeListener(_onResult);
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       body: Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -58,23 +60,18 @@ class _LoginScreenState extends State<LoginScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                TextField(controller: _email),
+                TextField(controller: email),
                 const SizedBox(height: Dimens.paddingVertical),
-                TextField(controller: _password, obscureText: true),
+                TextField(controller: password, obscureText: true),
                 const SizedBox(height: Dimens.paddingVertical),
-                ListenableBuilder(
-                  listenable: widget.viewModel.login,
-                  builder: (context, _) {
-                    return FilledButton(
-                      onPressed: () {
-                        widget.viewModel.login.execute((
-                          _email.value.text,
-                          _password.value.text,
-                        ));
-                      },
-                      child: Text(AppLocalization.of(context).login),
-                    );
+                FilledButton(
+                  onPressed: () {
+                    viewModel.login.execute((
+                      email.value.text,
+                      password.value.text,
+                    ));
                   },
+                  child: Text(AppLocalization.of(context).login),
                 ),
               ],
             ),
@@ -82,29 +79,5 @@ class _LoginScreenState extends State<LoginScreen> {
         ],
       ),
     );
-  }
-
-  void _onResult() {
-    if (widget.viewModel.login.value.isSuccess) {
-      widget.viewModel.login.reset();
-      context.go(Routes.home);
-    }
-
-    if (widget.viewModel.login.value.isFailure) {
-      widget.viewModel.login.reset();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalization.of(context).errorWhileLogin),
-          action: SnackBarAction(
-            label: AppLocalization.of(context).tryAgain,
-            onPressed:
-                () => widget.viewModel.login.execute((
-                  _email.value.text,
-                  _password.value.text,
-                )),
-          ),
-        ),
-      );
-    }
   }
 }

--- a/app/lib/ui/auth/logout/widgets/logout_button.dart
+++ b/app/lib/ui/auth/logout/widgets/logout_button.dart
@@ -6,38 +6,37 @@ import 'package:compass_app/ui/auth/logout/view_models/logout_viewmodel.dart';
 import 'package:compass_app/ui/core/localization/applocalization.dart';
 import 'package:compass_app/ui/core/themes/colors.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
-class LogoutButton extends StatefulWidget {
+class LogoutButton extends HookConsumerWidget {
   const LogoutButton({required this.viewModel, super.key});
 
   final LogoutViewModel viewModel;
 
   @override
-  State<LogoutButton> createState() => _LogoutButtonState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    void onResult() {
+      // We do not need to navigate to `/login` on logout,
+      // it is done automatically by GoRouter.
+      if (viewModel.logout.value.isFailure) {
+        viewModel.logout.reset();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppLocalization.of(context).errorWhileLogout),
+            action: SnackBarAction(
+              label: AppLocalization.of(context).tryAgain,
+              onPressed: viewModel.logout.execute,
+            ),
+          ),
+        );
+      }
+    }
 
-class _LogoutButtonState extends State<LogoutButton> {
-  @override
-  void initState() {
-    super.initState();
-    widget.viewModel.logout.addListener(_onResult);
-  }
+    useEffect(() {
+      viewModel.logout.addListener(onResult);
+      return () => viewModel.logout.removeListener(onResult);
+    }, [viewModel]);
 
-  @override
-  void didUpdateWidget(covariant LogoutButton oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    oldWidget.viewModel.logout.removeListener(_onResult);
-    widget.viewModel.logout.addListener(_onResult);
-  }
-
-  @override
-  void dispose() {
-    widget.viewModel.logout.removeListener(_onResult);
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return SizedBox(
       height: 40,
       width: 40,
@@ -50,7 +49,7 @@ class _LogoutButtonState extends State<LogoutButton> {
         child: InkResponse(
           borderRadius: BorderRadius.circular(8),
           onTap: () {
-            widget.viewModel.logout.execute();
+            viewModel.logout.execute();
           },
           child: Center(
             child: Icon(
@@ -62,23 +61,5 @@ class _LogoutButtonState extends State<LogoutButton> {
         ),
       ),
     );
-  }
-
-  void _onResult() {
-    // We do not need to navigate to `/login` on logout,
-    // it is done automatically by GoRouter.
-
-    if (widget.viewModel.logout.value.isFailure) {
-      widget.viewModel.logout.reset();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalization.of(context).errorWhileLogout),
-          action: SnackBarAction(
-            label: AppLocalization.of(context).tryAgain,
-            onPressed: widget.viewModel.logout.execute,
-          ),
-        ),
-      );
-    }
   }
 }

--- a/app/lib/ui/booking/widgets/booking_screen.dart
+++ b/app/lib/ui/booking/widgets/booking_screen.dart
@@ -8,78 +8,70 @@ import 'package:compass_app/ui/booking/widgets/booking_body.dart';
 import 'package:compass_app/ui/core/localization/applocalization.dart';
 import 'package:compass_app/ui/core/ui/error_indicator.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 
-class BookingScreen extends StatefulWidget {
+class BookingScreen extends HookConsumerWidget {
   const BookingScreen({required this.viewModel, super.key});
 
   final BookingViewModel viewModel;
 
   @override
-  State<BookingScreen> createState() => _BookingScreenState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    void listener() {
+      if (viewModel.shareBooking.value.isFailure) {
+        viewModel.shareBooking.reset();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppLocalization.of(context).errorWhileSharing),
+            action: SnackBarAction(
+              label: AppLocalization.of(context).tryAgain,
+              onPressed: viewModel.shareBooking.execute,
+            ),
+          ),
+        );
+      }
+    }
 
-class _BookingScreenState extends State<BookingScreen> {
-  @override
-  void initState() {
-    super.initState();
-    widget.viewModel.shareBooking.addListener(_listener);
-  }
+    useEffect(() {
+      viewModel.shareBooking.addListener(listener);
+      return () => viewModel.shareBooking.removeListener(listener);
+    }, [viewModel]);
 
-  @override
-  void dispose() {
-    widget.viewModel.shareBooking.removeListener(_listener);
-    super.dispose();
-  }
+    useListenable(viewModel);
+    useListenable(viewModel.createBooking);
+    useListenable(viewModel.loadBooking);
 
-  @override
-  Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, r) {
-        // Back navigation always goes to home
         if (!didPop) context.go(Routes.home);
       },
       child: Scaffold(
-        floatingActionButton: ListenableBuilder(
-          listenable: widget.viewModel,
-          builder:
-              (context, _) => FloatingActionButton.extended(
-                // Workaround for https://github.com/flutter/flutter/issues/115358#issuecomment-2117157419
-                heroTag: null,
-                key: const ValueKey('share-button'),
-                onPressed:
-                    widget.viewModel.booking != null
-                        ? widget.viewModel.shareBooking.execute
-                        : null,
-                label: Text(AppLocalization.of(context).shareTrip),
-                icon: const Icon(Icons.share_outlined),
-              ),
+        floatingActionButton: FloatingActionButton.extended(
+          heroTag: null, // Workaround for https://github.com/flutter/flutter/issues/115358#issuecomment-2117157419
+          key: const ValueKey('share-button'),
+          onPressed:
+              viewModel.booking != null ? viewModel.shareBooking.execute : null,
+          label: Text(AppLocalization.of(context).shareTrip),
+          icon: const Icon(Icons.share_outlined),
         ),
-        body: ListenableBuilder(
-          // Listen to changes in both commands
-          listenable: Listenable.merge([
-            widget.viewModel.createBooking,
-            widget.viewModel.loadBooking,
-          ]),
-          builder: (context, child) {
-            // If either command is running, show progress indicator
-            if (widget.viewModel.createBooking.value.isRunning ||
-                widget.viewModel.loadBooking.value.isRunning) {
+        body: Builder(
+          builder: (context) {
+            if (viewModel.createBooking.value.isRunning ||
+                viewModel.loadBooking.value.isRunning) {
               return const Center(child: CircularProgressIndicator());
             }
-            // If fails to create booking, tap to try again
-            if (widget.viewModel.createBooking.value.isFailure) {
+            if (viewModel.createBooking.value.isFailure) {
               return Center(
                 child: ErrorIndicator(
                   title: AppLocalization.of(context).errorWhileLoadingBooking,
                   label: AppLocalization.of(context).tryAgain,
-                  onPressed: widget.viewModel.createBooking.execute,
+                  onPressed: viewModel.createBooking.execute,
                 ),
               );
             }
-            // If existing booking fails to load, tap to go /home
-            if (widget.viewModel.loadBooking.value.isFailure) {
+            if (viewModel.loadBooking.value.isFailure) {
               return Center(
                 child: ErrorIndicator(
                   title: AppLocalization.of(context).errorWhileLoadingBooking,
@@ -88,26 +80,10 @@ class _BookingScreenState extends State<BookingScreen> {
                 ),
               );
             }
-            return child!;
+            return BookingBody(viewModel: viewModel);
           },
-          child: BookingBody(viewModel: widget.viewModel),
         ),
       ),
     );
-  }
-
-  void _listener() {
-    if (widget.viewModel.shareBooking.value.isFailure) {
-      widget.viewModel.shareBooking.reset();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalization.of(context).errorWhileSharing),
-          action: SnackBarAction(
-            label: AppLocalization.of(context).tryAgain,
-            onPressed: widget.viewModel.shareBooking.execute,
-          ),
-        ),
-      );
-    }
   }
 }

--- a/app/test/ui/auth/login_screen_test.dart
+++ b/app/test/ui/auth/login_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:mocktail_image_network/mocktail_image_network.dart';
 import '../../../testing/app.dart';
 import '../../../testing/fakes/repositories/fake_auth_repository.dart';
 import '../../../testing/mocks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
   group('LoginScreen test', () {
@@ -27,7 +28,9 @@ void main() {
     Future<void> loadScreen(WidgetTester tester) async {
       await testApp(
         tester,
-        LoginScreen(viewModel: viewModel),
+        ProviderScope(
+          child: LoginScreen(viewModel: viewModel),
+        ),
         goRouter: goRouter,
       );
     }

--- a/app/test/ui/booking/booking_screen_test.dart
+++ b/app/test/ui/booking/booking_screen_test.dart
@@ -21,6 +21,7 @@ import '../../../testing/mocks.dart';
 import '../../../testing/models/activity.dart';
 import '../../../testing/models/booking.dart';
 import '../../../testing/models/destination.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
   group('BookingScreen widget tests', () {
@@ -59,7 +60,9 @@ void main() {
     Future<void> loadScreen(WidgetTester tester) async {
       await testApp(
         tester,
-        BookingScreen(viewModel: viewModel),
+        ProviderScope(
+          child: BookingScreen(viewModel: viewModel),
+        ),
         goRouter: goRouter,
       );
     }


### PR DESCRIPTION
## Summary
- migrate `LoginScreen`, `LogoutButton` and `BookingScreen` to `HookConsumerWidget`
- update widget tests with `ProviderScope`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d6014d360832283397ea48d317a69