### PR TITLE
Refactor activities and results widgets to hooks

### DIFF
--- a/app/lib/ui/activities/widgets/activities_screen.dart
+++ b/app/lib/ui/activities/widgets/activities_screen.dart
@@ -12,137 +12,115 @@ import 'package:compass_app/ui/core/localization/applocalization.dart';
 import 'package:compass_app/ui/core/themes/dimens.dart';
 import 'package:compass_app/ui/core/ui/error_indicator.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 const String confirmButtonKey = 'confirm-button';
 
-class ActivitiesScreen extends StatefulWidget {
+class ActivitiesScreen extends HookConsumerWidget {
   const ActivitiesScreen({required this.viewModel, super.key});
 
   final ActivitiesViewModel viewModel;
 
   @override
-  State<ActivitiesScreen> createState() => _ActivitiesScreenState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    void listener() {
+      if (viewModel.saveActivities.value.isSuccess) {
+        viewModel.saveActivities.reset();
+        context.go(Routes.booking);
+      }
 
-class _ActivitiesScreenState extends State<ActivitiesScreen> {
-  @override
-  void initState() {
-    super.initState();
-    widget.viewModel.saveActivities.addListener(_onResult);
-  }
+      if (viewModel.saveActivities.value.isFailure) {
+        viewModel.saveActivities.reset();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content:
+                Text(AppLocalization.of(context).errorWhileSavingActivities),
+            action: SnackBarAction(
+              label: AppLocalization.of(context).tryAgain,
+              onPressed: viewModel.saveActivities.execute,
+            ),
+          ),
+        );
+      }
+    }
 
-  @override
-  void didUpdateWidget(covariant ActivitiesScreen oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    oldWidget.viewModel.saveActivities.removeListener(_onResult);
-    widget.viewModel.saveActivities.addListener(_onResult);
-  }
+    useEffect(() {
+      viewModel.saveActivities.addListener(listener);
+      return () => viewModel.saveActivities.removeListener(listener);
+    }, [viewModel]);
 
-  @override
-  void dispose() {
-    widget.viewModel.saveActivities.removeListener(_onResult);
-    super.dispose();
-  }
+    useListenable(viewModel);
+    useListenable(viewModel.loadActivities);
+    useListenable(viewModel.saveActivities);
 
-  @override
-  Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, r) {
         if (!didPop) context.go(Routes.results);
       },
       child: Scaffold(
-        body: ListenableBuilder(
-          listenable: widget.viewModel.loadActivities,
-          builder: (context, child) {
-            if (widget.viewModel.loadActivities.value.isSuccess) {
-              // The getter 'completed' isn't defined for the type
-              // 'Command0<Object>'.
-              // Try importing the library that defines 'completed', correcting
-              // the name to the name of an existing getter, or defining a
-              // getter or field named 'completed'.
-              return child!;
+        body: Builder(
+          builder: (context) {
+            if (viewModel.loadActivities.value.isRunning) {
+              return Column(
+                children: const [
+                  ActivitiesHeader(),
+                  Expanded(child: Center(child: CircularProgressIndicator())),
+                ],
+              );
             }
-            return Column(
-              children: [
-                const ActivitiesHeader(),
-                if (widget.viewModel.loadActivities.value.isRunning)
-                  const Expanded(
-                    child: Center(child: CircularProgressIndicator()),
-                  ),
-                if (widget.viewModel.loadActivities.value.isFailure)
+            if (viewModel.loadActivities.value.isFailure) {
+              return Column(
+                children: [
+                  const ActivitiesHeader(),
                   Expanded(
                     child: Center(
                       child: ErrorIndicator(
-                        title:
-                            AppLocalization.of(
-                              context,
-                            ).errorWhileLoadingActivities,
+                        title: AppLocalization.of(context)
+                            .errorWhileLoadingActivities,
                         label: AppLocalization.of(context).tryAgain,
-                        onPressed: widget.viewModel.loadActivities.execute,
+                        onPressed: viewModel.loadActivities.execute,
                       ),
                     ),
                   ),
+                ],
+              );
+            }
+
+            return Column(
+              children: [
+                Expanded(
+                  child: CustomScrollView(
+                    slivers: [
+                      const SliverToBoxAdapter(child: ActivitiesHeader()),
+                      ActivitiesTitle(
+                        viewModel: viewModel,
+                        activityTimeOfDay: ActivityTimeOfDay.daytime,
+                      ),
+                      ActivitiesList(
+                        viewModel: viewModel,
+                        activityTimeOfDay: ActivityTimeOfDay.daytime,
+                      ),
+                      ActivitiesTitle(
+                        viewModel: viewModel,
+                        activityTimeOfDay: ActivityTimeOfDay.evening,
+                      ),
+                      ActivitiesList(
+                        viewModel: viewModel,
+                        activityTimeOfDay: ActivityTimeOfDay.evening,
+                      ),
+                    ],
+                  ),
+                ),
+                _BottomArea(viewModel: viewModel),
               ],
             );
           },
-          child: ListenableBuilder(
-            listenable: widget.viewModel,
-            builder: (context, child) {
-              return Column(
-                children: [
-                  Expanded(
-                    child: CustomScrollView(
-                      slivers: [
-                        const SliverToBoxAdapter(child: ActivitiesHeader()),
-                        ActivitiesTitle(
-                          viewModel: widget.viewModel,
-                          activityTimeOfDay: ActivityTimeOfDay.daytime,
-                        ),
-                        ActivitiesList(
-                          viewModel: widget.viewModel,
-                          activityTimeOfDay: ActivityTimeOfDay.daytime,
-                        ),
-                        ActivitiesTitle(
-                          viewModel: widget.viewModel,
-                          activityTimeOfDay: ActivityTimeOfDay.evening,
-                        ),
-                        ActivitiesList(
-                          viewModel: widget.viewModel,
-                          activityTimeOfDay: ActivityTimeOfDay.evening,
-                        ),
-                      ],
-                    ),
-                  ),
-                  _BottomArea(viewModel: widget.viewModel),
-                ],
-              );
-            },
-          ),
         ),
       ),
     );
-  }
-
-  void _onResult() {
-    if (widget.viewModel.saveActivities.value.isSuccess) {
-      widget.viewModel.saveActivities.reset();
-      context.go(Routes.booking);
-    }
-
-    if (widget.viewModel.saveActivities.value.isFailure) {
-      widget.viewModel.saveActivities.reset();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalization.of(context).errorWhileSavingActivities),
-          action: SnackBarAction(
-            label: AppLocalization.of(context).tryAgain,
-            onPressed: widget.viewModel.saveActivities.execute,
-          ),
-        ),
-      );
-    }
   }
 }
 

--- a/app/lib/ui/results/widgets/results_screen.dart
+++ b/app/lib/ui/results/widgets/results_screen.dart
@@ -10,114 +10,98 @@ import 'package:compass_app/ui/core/ui/search_bar.dart';
 import 'package:compass_app/ui/results/view_models/results_viewmodel.dart';
 import 'package:compass_app/ui/results/widgets/result_card.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class ResultsScreen extends StatefulWidget {
+class ResultsScreen extends HookConsumerWidget {
   const ResultsScreen({required this.viewModel, super.key});
 
   final ResultsViewModel viewModel;
 
   @override
-  State<ResultsScreen> createState() => _ResultsScreenState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    void listener() {
+      if (viewModel.updateItineraryConfig.value.isSuccess) {
+        viewModel.updateItineraryConfig.reset();
+        context.go(Routes.activities);
+      }
 
-class _ResultsScreenState extends State<ResultsScreen> {
-  @override
-  void initState() {
-    super.initState();
-    widget.viewModel.updateItineraryConfig.addListener(_onResult);
-  }
+      if (viewModel.updateItineraryConfig.value.isFailure) {
+        viewModel.updateItineraryConfig.reset();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content:
+                Text(AppLocalization.of(context).errorWhileSavingItinerary),
+          ),
+        );
+      }
+    }
 
-  @override
-  void didUpdateWidget(covariant ResultsScreen oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    oldWidget.viewModel.updateItineraryConfig.removeListener(_onResult);
-    widget.viewModel.updateItineraryConfig.addListener(_onResult);
-  }
+    useEffect(() {
+      viewModel.updateItineraryConfig.addListener(listener);
+      return () => viewModel.updateItineraryConfig.removeListener(listener);
+    }, [viewModel]);
 
-  @override
-  void dispose() {
-    widget.viewModel.updateItineraryConfig.removeListener(_onResult);
-    super.dispose();
-  }
+    useListenable(viewModel);
+    useListenable(viewModel.search);
+    useListenable(viewModel.updateItineraryConfig);
 
-  @override
-  Widget build(BuildContext context) {
+    return PopScope(
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, r) {
         if (!didPop) context.go(Routes.search);
       },
       child: Scaffold(
-        body: ListenableBuilder(
-          listenable: widget.viewModel.search,
-          builder: (context, child) {
-            if (widget.viewModel.search.value.isSuccess) {
-              return child!;
+        body: Builder(
+          builder: (context) {
+            if (viewModel.search.value.isRunning) {
+              return Column(
+                children: [
+                  _AppSearchBar(viewModel: viewModel),
+                  Expanded(child: Center(child: CircularProgressIndicator())),
+                ],
+              );
             }
-            return Column(
-              children: [
-                _AppSearchBar(widget: widget),
-                if (widget.viewModel.search.value.isRunning)
-                  const Expanded(
-                    child: Center(child: CircularProgressIndicator()),
-                  ),
-                if (widget.viewModel.search.value.isFailure)
+            if (viewModel.search.value.isFailure) {
+              return Column(
+                children: [
+                  _AppSearchBar(viewModel: viewModel),
                   Expanded(
                     child: Center(
                       child: ErrorIndicator(
-                        title:
-                            AppLocalization.of(
-                              context,
-                            ).errorWhileLoadingDestinations,
+                        title: AppLocalization.of(context)
+                            .errorWhileLoadingDestinations,
                         label: AppLocalization.of(context).tryAgain,
-                        onPressed: widget.viewModel.search.execute,
+                        onPressed: viewModel.search.execute,
                       ),
                     ),
                   ),
-              ],
+                ],
+              );
+            }
+
+            return Padding(
+              padding: Dimens.of(context).edgeInsetsScreenHorizontal,
+              child: CustomScrollView(
+                slivers: [
+                  SliverToBoxAdapter(child: _AppSearchBar(viewModel: viewModel)),
+                  _Grid(viewModel: viewModel),
+                ],
+              ),
             );
           },
-          child: ListenableBuilder(
-            listenable: widget.viewModel,
-            builder: (context, child) {
-              return Padding(
-                padding: Dimens.of(context).edgeInsetsScreenHorizontal,
-                child: CustomScrollView(
-                  slivers: [
-                    SliverToBoxAdapter(child: _AppSearchBar(widget: widget)),
-                    _Grid(viewModel: widget.viewModel),
-                  ],
-                ),
-              );
-            },
-          ),
         ),
       ),
     );
   }
-
-  void _onResult() {
-    if (widget.viewModel.updateItineraryConfig.value.isSuccess) {
-      widget.viewModel.updateItineraryConfig.reset();
-      context.go(Routes.activities);
-    }
-
-    if (widget.viewModel.updateItineraryConfig.value.isFailure) {
-      widget.viewModel.updateItineraryConfig.reset();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalization.of(context).errorWhileSavingItinerary),
-        ),
-      );
-    }
-  }
 }
 
 class _AppSearchBar extends StatelessWidget {
-  const _AppSearchBar({required this.widget});
+  const _AppSearchBar({required this.viewModel});
 
-  final ResultsScreen widget;
+  final ResultsViewModel viewModel;
 
   @override
   Widget build(BuildContext context) {
@@ -129,7 +113,7 @@ class _AppSearchBar extends StatelessWidget {
           bottom: Dimens.mobile.paddingScreenVertical,
         ),
         child: AppSearchBar(
-          config: widget.viewModel.config,
+          config: viewModel.config,
           // onTap: () {
           //   // Navigate to SearchFormScreen and edit search
           // context.pop();


### PR DESCRIPTION
## Summary
- migrate activities and results screens from StatefulWidget to HookConsumerWidget
- use hooks to manage command listeners and rebuilds

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d690d08f4832286c490561ea01926