### PR TITLE
Refactor state management to Riverpod

### DIFF
--- a/app/lib/config/dependencies.dart
+++ b/app/lib/config/dependencies.dart
@@ -26,6 +26,7 @@ import 'package:compass_app/data/services/api/api_client.dart';
 import 'package:compass_app/data/services/api/auth_api_client.dart';
 import 'package:compass_app/data/services/local/local_data_service.dart';
 import 'package:compass_app/data/services/shared_preferences_service.dart';
+import 'package:compass_app/ui/auth/auth_controller.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_create_use_case.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_share_use_case.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -48,13 +49,18 @@ final Provider<LocalDataService> localDataServiceProvider = Provider(
 );
 
 /// Authentication repository used by the router to check login state.
-final authRepositoryProvider = ChangeNotifierProvider<AuthRepository>((ref) {
+/// Authentication repository used by [AuthController].
+final authRepositoryProvider = Provider<AuthRepository>((ref) {
   return AuthRepositoryRemote(
     apiClient: ref.read(apiClientProvider),
     authApiClient: ref.read(authApiClientProvider),
     sharedPreferencesService: ref.read(sharedPreferencesServiceProvider),
   );
 });
+
+/// Authentication controller exposing the user's login state.
+final authControllerProvider =
+    AsyncNotifierProvider<AuthController, bool>(AuthController.new);
 
 /// Destination repository implementation.
 final destinationRepositoryProvider = Provider<DestinationRepository>((ref) {

--- a/app/lib/data/repositories/auth/auth_repository.dart
+++ b/app/lib/data/repositories/auth/auth_repository.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:result_dart/result_dart.dart';
 
-abstract class AuthRepository extends ChangeNotifier {
+abstract class AuthRepository {
   /// Returns true when the user is logged in
   /// Returns [Future] because it will load a stored auth state the first time.
   Future<bool> get isAuthenticated;

--- a/app/lib/data/repositories/auth/auth_repository_remote.dart
+++ b/app/lib/data/repositories/auth/auth_repository_remote.dart
@@ -79,7 +79,7 @@ class AuthRepositoryRemote extends AuthRepository {
         return Failure(error ?? Exception('Unknown error'));
       }
     } finally {
-      notifyListeners();
+      // State changes are handled by [AuthController].
     }
   }
 
@@ -99,7 +99,7 @@ class AuthRepositoryRemote extends AuthRepository {
       _isAuthenticated = false;
       return result;
     } finally {
-      notifyListeners();
+      // State changes are handled by [AuthController].
     }
   }
 

--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -18,6 +18,8 @@ import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dar
 import 'package:compass_app/ui/search_form/widgets/search_form_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
+import 'package:go_router/go_router.dart' show GoRouterRefreshStream;
+import 'package:compass_app/ui/auth/auth_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Top go_router entry point.
@@ -27,12 +29,12 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 typedef Reader = T Function<T>(ProviderListenable<T> provider);
 
 final routerProvider = Provider<GoRouter>((ref) {
-  final authRepository = ref.watch(authRepositoryProvider);
+  final refresh = GoRouterRefreshStream(ref.watch(authControllerProvider.stream));
   return GoRouter(
     initialLocation: Routes.home,
     debugLogDiagnostics: true,
     redirect: (context, state) => _redirect(context, state, ref.read),
-    refreshListenable: authRepository,
+    refreshListenable: refresh,
     routes: [
       GoRoute(
         path: Routes.login,
@@ -40,7 +42,7 @@ final routerProvider = Provider<GoRouter>((ref) {
           return Consumer(
             builder: (context, ref, _) {
               final viewModel = LoginViewModel(
-                authRepository: ref.read(authRepositoryProvider),
+                authController: ref.read(authControllerProvider.notifier),
               );
               return LoginScreen(viewModel: viewModel);
             },
@@ -116,22 +118,13 @@ final routerProvider = Provider<GoRouter>((ref) {
             builder: (context, state) {
               return Consumer(
                 builder: (context, ref, _) {
-                  final viewModel = BookingViewModel(
-                    itineraryConfigRepository: ref.read(
-                      itineraryConfigRepositoryProvider,
-                    ),
-                    createBookingUseCase: ref.read(
-                      bookingCreateUseCaseProvider,
-                    ),
-                    shareBookingUseCase: ref.read(bookingShareUseCaseProvider),
-                    bookingRepository: ref.read(bookingRepositoryProvider),
-                  );
+                  final notifier = ref.read(bookingViewModelProvider.notifier);
 
-                  // When opening the booking screen directly
-                  // create a new booking from the stored ItineraryConfig.
-                  viewModel.createBooking.execute();
+                  // When opening the booking screen directly create a booking
+                  // from the stored ItineraryConfig.
+                  notifier.createBooking.execute();
 
-                  return BookingScreen(viewModel: viewModel);
+                  return const BookingScreen();
                 },
               );
             },
@@ -142,24 +135,13 @@ final routerProvider = Provider<GoRouter>((ref) {
                   final id = int.parse(state.pathParameters['id']!);
                   return Consumer(
                     builder: (context, ref, _) {
-                      final viewModel = BookingViewModel(
-                        itineraryConfigRepository: ref.read(
-                          itineraryConfigRepositoryProvider,
-                        ),
-                        createBookingUseCase: ref.read(
-                          bookingCreateUseCaseProvider,
-                        ),
-                        shareBookingUseCase: ref.read(
-                          bookingShareUseCaseProvider,
-                        ),
-                        bookingRepository: ref.read(bookingRepositoryProvider),
-                      );
+                      final notifier =
+                          ref.read(bookingViewModelProvider.notifier);
 
-                      // When opening the booking screen with an existing id
-                      // load and display that booking.
-                      viewModel.loadBooking.execute(id);
+                      // Load and display booking with given id.
+                      notifier.loadBooking.execute(id);
 
-                      return BookingScreen(viewModel: viewModel);
+                      return const BookingScreen();
                     },
                   );
                 },
@@ -179,7 +161,7 @@ Future<String?> _redirect(
   Reader read,
 ) async {
   // if the user is not logged in, they need to login
-  final loggedIn = await read(authRepositoryProvider).isAuthenticated;
+  final loggedIn = await read(authControllerProvider.future);
   final loggingIn = state.matchedLocation == Routes.login;
   if (!loggedIn) {
     return Routes.login;

--- a/app/lib/ui/auth/auth_controller.dart
+++ b/app/lib/ui/auth/auth_controller.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:compass_app/config/dependencies.dart';
+import 'package:compass_app/data/repositories/auth/auth_repository.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:result_dart/result_dart.dart';
+
+/// Notifier that exposes the authentication status and operations.
+class AuthController extends AsyncNotifier<bool> {
+  late final AuthRepository _authRepository;
+
+  @override
+  FutureOr<bool> build() async {
+    _authRepository = ref.read(authRepositoryProvider);
+    return _authRepository.isAuthenticated;
+  }
+
+  /// Perform login and update the authentication state.
+  Future<Result<Unit>> login({required String email, required String password}) async {
+    final result = await _authRepository.login(email: email, password: password);
+    state = AsyncData(await _authRepository.isAuthenticated);
+    return result;
+  }
+
+  /// Perform logout and update the authentication state.
+  Future<Result<Unit>> logout() async {
+    final result = await _authRepository.logout();
+    state = AsyncData(await _authRepository.isAuthenticated);
+    return result;
+  }
+}
+
+/// Provider for the [AuthController].
+final authControllerProvider =
+    AsyncNotifierProvider<AuthController, bool>(AuthController.new);

--- a/app/lib/ui/auth/login/view_models/login_viewmodel.dart
+++ b/app/lib/ui/auth/login/view_models/login_viewmodel.dart
@@ -2,25 +2,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:compass_app/data/repositories/auth/auth_repository.dart';
+import 'package:compass_app/ui/auth/auth_controller.dart';
 import 'package:logging/logging.dart';
 import 'package:result_command/result_command.dart';
 import 'package:result_dart/result_dart.dart';
 
 class LoginViewModel {
-  LoginViewModel({required AuthRepository authRepository})
-    : _authRepository = authRepository {
+  LoginViewModel({required AuthController authController})
+    : _authController = authController {
     login = Command1<Unit, (String email, String password)>(_login);
   }
 
-  final AuthRepository _authRepository;
+  final AuthController _authController;
   final _log = Logger('LoginViewModel');
 
   late Command1<Object, dynamic> login;
 
   Future<Result<Unit>> _login((String, String) credentials) async {
     final (email, password) = credentials;
-    final result = await _authRepository.login(
+    final result = await _authController.login(
       email: email,
       password: password,
     );

--- a/app/lib/ui/auth/logout/view_models/logout_viewmodel.dart
+++ b/app/lib/ui/auth/logout/view_models/logout_viewmodel.dart
@@ -1,4 +1,4 @@
-import 'package:compass_app/data/repositories/auth/auth_repository.dart';
+import 'package:compass_app/ui/auth/auth_controller.dart';
 import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_repository.dart';
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
 import 'package:result_command/result_command.dart';
@@ -6,19 +6,19 @@ import 'package:result_dart/result_dart.dart';
 
 class LogoutViewModel {
   LogoutViewModel({
-    required AuthRepository authRepository,
+    required AuthController authController,
     required ItineraryConfigRepository itineraryConfigRepository,
-  }) : _authLogoutRepository = authRepository,
+  }) : _authController = authController,
        _itineraryConfigRepository = itineraryConfigRepository {
     logout = Command0(_logout);
   }
 
-  final AuthRepository _authLogoutRepository;
+  final AuthController _authController;
   final ItineraryConfigRepository _itineraryConfigRepository;
   late Command0 logout;
 
   Future<Result<Unit>> _logout() async {
-    final result = await _authLogoutRepository.logout();
+    final result = await _authController.logout();
     if (result.isError()) {
       return Failure(result.exceptionOrNull() ?? Exception('Logout failed'));
     }

--- a/app/lib/ui/booking/view_models/booking_viewmodel.dart
+++ b/app/lib/ui/booking/view_models/booking_viewmodel.dart
@@ -3,34 +3,34 @@ import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_
 import 'package:compass_app/domain/models/booking/booking.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_create_use_case.dart';
 import 'package:compass_app/domain/use_cases/booking/booking_share_use_case.dart';
-import 'package:flutter/foundation.dart';
+import 'package:compass_app/config/dependencies.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:result_command/result_command.dart';
 import 'package:result_dart/result_dart.dart';
 
-class BookingViewModel extends ChangeNotifier {
-  BookingViewModel({
-    required BookingCreateUseCase createBookingUseCase,
-    required BookingShareUseCase shareBookingUseCase,
-    required ItineraryConfigRepository itineraryConfigRepository,
-    required BookingRepository bookingRepository,
-  }) : _createUseCase = createBookingUseCase,
-       _shareUseCase = shareBookingUseCase,
-       _itineraryConfigRepository = itineraryConfigRepository,
-       _bookingRepository = bookingRepository {
+class BookingViewModel extends Notifier<Booking?> {
+  late BookingCreateUseCase _createUseCase;
+  late BookingShareUseCase _shareUseCase;
+  late ItineraryConfigRepository _itineraryConfigRepository;
+  late BookingRepository _bookingRepository;
+
+  @override
+  Booking? build() {
+    _createUseCase = ref.read(bookingCreateUseCaseProvider);
+    _shareUseCase = ref.read(bookingShareUseCaseProvider);
+    _itineraryConfigRepository = ref.read(itineraryConfigRepositoryProvider);
+    _bookingRepository = ref.read(bookingRepositoryProvider);
     createBooking = Command0(_createBooking);
-    shareBooking = Command0(() => _shareUseCase.shareBooking(_booking!));
+    shareBooking = Command0(() => _shareUseCase.shareBooking(state!));
     loadBooking = Command1(_load);
+    return null;
   }
 
-  final BookingCreateUseCase _createUseCase;
-  final BookingShareUseCase _shareUseCase;
-  final ItineraryConfigRepository _itineraryConfigRepository;
-  final BookingRepository _bookingRepository;
   final _log = Logger('BookingViewModel');
-  Booking? _booking;
 
-  Booking? get booking => _booking;
+  /// Current booking loaded or created.
+  Booking? get booking => state;
 
   /// Creates a booking from the ItineraryConfig
   /// and saves it to the user bookings
@@ -50,7 +50,6 @@ class BookingViewModel extends ChangeNotifier {
       _log.warning(
         'ItineraryConfig error: ${itineraryResult.exceptionOrNull()}',
       );
-      notifyListeners();
       return Failure(
         itineraryResult.exceptionOrNull() ??
             Exception('Unknown ItineraryConfig error'),
@@ -63,14 +62,12 @@ class BookingViewModel extends ChangeNotifier {
     );
     if (bookingResult.isError()) {
       _log.warning('Booking error: ${bookingResult.exceptionOrNull()}');
-      notifyListeners();
       return Failure(
         bookingResult.exceptionOrNull() ?? Exception('Unknown Booking error'),
       );
     }
     _log.fine('Created Booking');
-    _booking = bookingResult.getOrThrow();
-    notifyListeners();
+    state = bookingResult.getOrThrow();
     return const Success(unit);
   }
 
@@ -83,8 +80,11 @@ class BookingViewModel extends ChangeNotifier {
       );
     }
     _log.fine('Loaded booking $id');
-    _booking = result.getOrThrow();
-    notifyListeners();
+    state = result.getOrThrow();
     return const Success(unit);
   }
 }
+
+/// Provider that exposes the [BookingViewModel] and its [Booking] state.
+final bookingViewModelProvider =
+    NotifierProvider<BookingViewModel, Booking?>(BookingViewModel.new);

--- a/app/lib/ui/booking/widgets/booking_screen.dart
+++ b/app/lib/ui/booking/widgets/booking_screen.dart
@@ -13,12 +13,13 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class BookingScreen extends HookConsumerWidget {
-  const BookingScreen({required this.viewModel, super.key});
-
-  final BookingViewModel viewModel;
+  const BookingScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(bookingViewModelProvider.notifier);
+    final booking = ref.watch(bookingViewModelProvider);
+
     void listener() {
       if (viewModel.shareBooking.value.isFailure) {
         viewModel.shareBooking.reset();
@@ -39,7 +40,6 @@ class BookingScreen extends HookConsumerWidget {
       return () => viewModel.shareBooking.removeListener(listener);
     }, [viewModel]);
 
-    useListenable(viewModel);
     useListenable(viewModel.createBooking);
     useListenable(viewModel.loadBooking);
 
@@ -53,9 +53,8 @@ class BookingScreen extends HookConsumerWidget {
           heroTag:
               null, // Workaround for https://github.com/flutter/flutter/issues/115358#issuecomment-2117157419
           key: const ValueKey('share-button'),
-          onPressed: viewModel.booking != null
-              ? viewModel.shareBooking.execute
-              : null,
+          onPressed:
+              booking != null ? viewModel.shareBooking.execute : null,
           label: Text(AppLocalization.of(context).shareTrip),
           icon: const Icon(Icons.share_outlined),
         ),

--- a/app/lib/ui/home/widgets/home_title.dart
+++ b/app/lib/ui/home/widgets/home_title.dart
@@ -5,6 +5,7 @@
 import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/auth/logout/view_models/logout_viewmodel.dart';
 import 'package:compass_app/ui/auth/logout/widgets/logout_button.dart';
+import 'package:compass_app/ui/auth/auth_controller.dart';
 import 'package:compass_app/ui/core/localization/applocalization.dart';
 import 'package:compass_app/ui/core/themes/dimens.dart';
 import 'package:compass_app/ui/home/view_models/home_viewmodel.dart';
@@ -39,7 +40,7 @@ class HomeHeader extends HookConsumerWidget {
             ),
             LogoutButton(
               viewModel: LogoutViewModel(
-                authRepository: ref.read(authRepositoryProvider),
+                authController: ref.read(authControllerProvider.notifier),
                 itineraryConfigRepository: ref.read(
                   itineraryConfigRepositoryProvider,
                 ),

--- a/app/test/ui/auth/login_screen_test.dart
+++ b/app/test/ui/auth/login_screen_test.dart
@@ -12,23 +12,34 @@ import 'package:mocktail_image_network/mocktail_image_network.dart';
 import '../../../testing/app.dart';
 import '../../../testing/fakes/repositories/fake_auth_repository.dart';
 import '../../../testing/mocks.dart';
+import 'package:compass_app/config/dependencies.dart';
 
 void main() {
   group('LoginScreen test', () {
     late LoginViewModel viewModel;
     late MockGoRouter goRouter;
     late FakeAuthRepository fakeAuthRepository;
+    late ProviderContainer container;
 
     setUp(() {
       fakeAuthRepository = FakeAuthRepository();
-      viewModel = LoginViewModel(authRepository: fakeAuthRepository);
+      container = ProviderContainer(overrides: [
+        authRepositoryProvider.overrideWithValue(fakeAuthRepository),
+      ]);
+      viewModel =
+          LoginViewModel(authController: container.read(authControllerProvider.notifier));
       goRouter = MockGoRouter();
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadScreen(WidgetTester tester) async {
       await testApp(
         tester,
-        ProviderScope(
+        UncontrolledProviderScope(
+          container: container,
           child: LoginScreen(viewModel: viewModel),
         ),
         goRouter: goRouter,

--- a/app/test/ui/auth/logout_button_test.dart
+++ b/app/test/ui/auth/logout_button_test.dart
@@ -12,6 +12,7 @@ import '../../../testing/app.dart';
 import '../../../testing/fakes/repositories/fake_auth_repository.dart';
 import '../../../testing/fakes/repositories/fake_itinerary_config_repository.dart';
 import '../../../testing/mocks.dart';
+import 'package:compass_app/config/dependencies.dart';
 
 void main() {
   group('LogoutButton test', () {
@@ -19,21 +20,27 @@ void main() {
     late FakeAuthRepository fakeAuthRepository;
     late FakeItineraryConfigRepository fakeItineraryConfigRepository;
     late LogoutViewModel viewModel;
+    late ProviderContainer container;
 
     setUp(() {
       goRouter = MockGoRouter();
       fakeAuthRepository =
           FakeAuthRepository()
-            // Setup a token, should be cleared after logout
             ..token = 'TOKEN';
-      // Setup an ItineraryConfig with some data, should be cleared after logout
       fakeItineraryConfigRepository = FakeItineraryConfigRepository(
         itineraryConfig: const ItineraryConfig(continent: 'CONTINENT'),
       );
+      container = ProviderContainer(overrides: [
+        authRepositoryProvider.overrideWithValue(fakeAuthRepository),
+      ]);
       viewModel = LogoutViewModel(
-        authRepository: fakeAuthRepository,
+        authController: container.read(authControllerProvider.notifier),
         itineraryConfigRepository: fakeItineraryConfigRepository,
       );
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadScreen(WidgetTester tester) async {

--- a/app/test/ui/booking/booking_screen_test.dart
+++ b/app/test/ui/booking/booking_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:compass_app/domain/use_cases/booking/booking_create_use_case.dar
 import 'package:compass_app/domain/use_cases/booking/booking_share_use_case.dart';
 import 'package:compass_app/ui/booking/view_models/booking_viewmodel.dart';
 import 'package:compass_app/ui/booking/widgets/booking_screen.dart';
+import 'package:compass_app/config/dependencies.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -29,39 +30,52 @@ void main() {
     late BookingViewModel viewModel;
     late bool shared;
     late FakeBookingRepository bookingRepository;
+    late ProviderContainer container;
 
     setUp(() {
       shared = false;
       bookingRepository = FakeBookingRepository();
-      viewModel = BookingViewModel(
-        itineraryConfigRepository: FakeItineraryConfigRepository(
-          itineraryConfig: ItineraryConfig(
-            continent: 'Europe',
-            startDate: DateTime(2024),
-            endDate: DateTime(2024, 01, 31),
-            guests: 2,
-            destination: kDestination1.ref,
-            activities: [kActivity.ref],
+      container = ProviderContainer(overrides: [
+        itineraryConfigRepositoryProvider.overrideWith(
+          (ref) => FakeItineraryConfigRepository(
+            itineraryConfig: ItineraryConfig(
+              continent: 'Europe',
+              startDate: DateTime(2024),
+              endDate: DateTime(2024, 01, 31),
+              guests: 2,
+              destination: kDestination1.ref,
+              activities: [kActivity.ref],
+            ),
           ),
         ),
-        createBookingUseCase: BookingCreateUseCase(
-          activityRepository: FakeActivityRepository(),
-          destinationRepository: FakeDestinationRepository(),
-          bookingRepository: bookingRepository,
+        bookingRepositoryProvider.overrideWithValue(bookingRepository),
+        bookingCreateUseCaseProvider.overrideWith(
+          (ref) => BookingCreateUseCase(
+            activityRepository: FakeActivityRepository(),
+            destinationRepository: FakeDestinationRepository(),
+            bookingRepository: bookingRepository,
+          ),
         ),
-        shareBookingUseCase: BookingShareUseCase.custom((text) async {
-          shared = true;
-        }),
-        bookingRepository: bookingRepository,
-      );
+        bookingShareUseCaseProvider.overrideWith(
+          (ref) => BookingShareUseCase.custom((text) async {
+                shared = true;
+              }),
+        ),
+      ]);
+      viewModel = container.read(bookingViewModelProvider.notifier);
       goRouter = MockGoRouter();
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadScreen(WidgetTester tester) async {
       await testApp(
         tester,
-        ProviderScope(
-          child: BookingScreen(viewModel: viewModel),
+        UncontrolledProviderScope(
+          container: container,
+          child: const BookingScreen(),
         ),
         goRouter: goRouter,
       );

--- a/app/testing/fakes/repositories/fake_auth_repository.dart
+++ b/app/testing/fakes/repositories/fake_auth_repository.dart
@@ -17,14 +17,12 @@ class FakeAuthRepository extends AuthRepository {
     required String password,
   }) async {
     token = 'TOKEN';
-    notifyListeners();
     return const Success(unit);
   }
 
   @override
   Future<Result<Unit>> logout() async {
     token = null;
-    notifyListeners();
     return const Success(unit);
   }
 }


### PR DESCRIPTION
## Summary
- introduce `AuthController` using Riverpod
- convert `BookingViewModel` to a Riverpod notifier
- update widgets and router for the new providers
- adjust fake repositories and tests for notifier based API

## Testing
- `dart` and `flutter` commands are unavailable in the environment, so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_686d77ebc8a48322a56c153139c14ee0