### PR TITLE
Refactor activities and results to use Riverpod

### DIFF
--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -81,37 +81,11 @@ final routerProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: Routes.resultsRelative,
-            builder: (context, state) {
-              return Consumer(
-                builder: (context, ref, _) {
-                  final viewModel = ResultsViewModel(
-                    destinationRepository: ref.read(
-                      destinationRepositoryProvider,
-                    ),
-                    itineraryConfigRepository: ref.read(
-                      itineraryConfigRepositoryProvider,
-                    ),
-                  );
-                  return ResultsScreen(viewModel: viewModel);
-                },
-              );
-            },
+            builder: (context, state) => const ResultsScreen(),
           ),
           GoRoute(
             path: Routes.activitiesRelative,
-            builder: (context, state) {
-              return Consumer(
-                builder: (context, ref, _) {
-                  final viewModel = ActivitiesViewModel(
-                    activityRepository: ref.read(activityRepositoryProvider),
-                    itineraryConfigRepository: ref.read(
-                      itineraryConfigRepositoryProvider,
-                    ),
-                  );
-                  return ActivitiesScreen(viewModel: viewModel);
-                },
-              );
-            },
+            builder: (context, state) => const ActivitiesScreen(),
           ),
           GoRoute(
             path: Routes.bookingRelative,

--- a/app/lib/ui/activities/view_models/activities_viewmodel.dart
+++ b/app/lib/ui/activities/view_models/activities_viewmodel.dart
@@ -3,36 +3,59 @@ import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_
 import 'package:compass_app/domain/models/activity/activity.dart';
 import 'package:compass_app/domain/models/destination/destination.dart'
     show Destination;
+import 'package:compass_app/config/dependencies.dart';
 import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:result_command/result_command.dart';
 import 'package:result_dart/result_dart.dart';
 
-class ActivitiesViewModel extends ChangeNotifier {
-  ActivitiesViewModel({
-    required ActivityRepository activityRepository,
-    required ItineraryConfigRepository itineraryConfigRepository,
-  }) : _activityRepository = activityRepository,
-       _itineraryConfigRepository = itineraryConfigRepository {
+/// Immutable state for [ActivitiesViewModel].
+@immutable
+class ActivitiesState {
+  const ActivitiesState({
+    this.daytimeActivities = const <Activity>[],
+    this.eveningActivities = const <Activity>[],
+    this.selectedActivities = const <String>{},
+  });
+
+  final List<Activity> daytimeActivities;
+  final List<Activity> eveningActivities;
+  final Set<String> selectedActivities;
+
+  ActivitiesState copyWith({
+    List<Activity>? daytimeActivities,
+    List<Activity>? eveningActivities,
+    Set<String>? selectedActivities,
+  }) {
+    return ActivitiesState(
+      daytimeActivities: daytimeActivities ?? this.daytimeActivities,
+      eveningActivities: eveningActivities ?? this.eveningActivities,
+      selectedActivities: selectedActivities ?? this.selectedActivities,
+    );
+  }
+}
+
+/// View model backed by Riverpod [Notifier].
+class ActivitiesViewModel extends Notifier<ActivitiesState> {
+  late ActivityRepository _activityRepository;
+  late ItineraryConfigRepository _itineraryConfigRepository;
+
+  @override
+  ActivitiesState build() {
+    _activityRepository = ref.read(activityRepositoryProvider);
+    _itineraryConfigRepository = ref.read(itineraryConfigRepositoryProvider);
     loadActivities = Command0(_loadActivities)..execute();
     saveActivities = Command0(_saveActivities);
+    return const ActivitiesState();
   }
 
   final _log = Logger('ActivitiesViewModel');
-  final ActivityRepository _activityRepository;
-  final ItineraryConfigRepository _itineraryConfigRepository;
-  List<Activity> _daytimeActivities = <Activity>[];
-  List<Activity> _eveningActivities = <Activity>[];
-  final Set<String> _selectedActivities = <String>{};
 
-  /// List of daytime [Activity] per destination.
-  List<Activity> get daytimeActivities => _daytimeActivities;
-
-  /// List of evening [Activity] per destination.
-  List<Activity> get eveningActivities => _eveningActivities;
-
-  /// Selected [Activity] by ref.
-  Set<String> get selectedActivities => _selectedActivities;
+  /// Current activities state.
+  List<Activity> get daytimeActivities => state.daytimeActivities;
+  List<Activity> get eveningActivities => state.eveningActivities;
+  Set<String> get selectedActivities => state.selectedActivities;
 
   /// Load list of [Activity] for a [Destination] by ref.
   late final Command0 loadActivities;
@@ -59,14 +82,14 @@ class ActivitiesViewModel extends ChangeNotifier {
       return Failure(Exception('Destination not found'));
     }
 
-    _selectedActivities.addAll(itineraryConfig.activities);
+    final selected = <String>{...itineraryConfig.activities};
 
     final resultActivities = await _activityRepository.getByDestination(
       destinationRef,
     );
     if (resultActivities.isSuccess()) {
       final activities = resultActivities.getOrThrow();
-      _daytimeActivities =
+      final daytime =
           activities
               .where(
                 (activity) => [
@@ -77,7 +100,7 @@ class ActivitiesViewModel extends ChangeNotifier {
               )
               .toList();
 
-      _eveningActivities =
+      final evening =
           activities
               .where(
                 (activity) => [
@@ -88,8 +111,12 @@ class ActivitiesViewModel extends ChangeNotifier {
               .toList();
 
       _log.fine(
-        'Activities (daytime: ${_daytimeActivities.length}, '
-        'evening: ${_eveningActivities.length}) loaded',
+        'Activities (daytime: ${daytime.length}, evening: ${evening.length}) loaded',
+      );
+      state = state.copyWith(
+        daytimeActivities: daytime,
+        eveningActivities: evening,
+        selectedActivities: selected,
       );
     } else {
       _log.warning(
@@ -98,34 +125,34 @@ class ActivitiesViewModel extends ChangeNotifier {
       );
     }
 
-    notifyListeners();
+    state = state.copyWith(selectedActivities: selected);
     return resultActivities.map((_) => unit);
   }
 
   /// Add [Activity] to selected list.
   void addActivity(String activityRef) {
     assert(
-      (_daytimeActivities + _eveningActivities).any(
+      (daytimeActivities + eveningActivities).any(
         (activity) => activity.ref == activityRef,
       ),
       'Activity $activityRef not found',
     );
-    _selectedActivities.add(activityRef);
+    final updated = <String>{...selectedActivities}..add(activityRef);
+    state = state.copyWith(selectedActivities: updated);
     _log.finest('Activity $activityRef added');
-    notifyListeners();
   }
 
   /// Remove [Activity] from selected list.
   void removeActivity(String activityRef) {
     assert(
-      (_daytimeActivities + _eveningActivities).any(
+      (daytimeActivities + eveningActivities).any(
         (activity) => activity.ref == activityRef,
       ),
       'Activity $activityRef not found',
     );
-    _selectedActivities.remove(activityRef);
+    final updated = <String>{...selectedActivities}..remove(activityRef);
+    state = state.copyWith(selectedActivities: updated);
     _log.finest('Activity $activityRef removed');
-    notifyListeners();
   }
 
   Future<Result<Unit>> _saveActivities() async {
@@ -143,7 +170,7 @@ class ActivitiesViewModel extends ChangeNotifier {
 
     final itineraryConfig = resultConfig.getOrThrow();
     final result = await _itineraryConfigRepository.setItineraryConfig(
-      itineraryConfig.copyWith(activities: _selectedActivities.toList()),
+      itineraryConfig.copyWith(activities: selectedActivities.toList()),
     );
     if (result.isError()) {
       _log.warning('Failed to store ItineraryConfig', result.exceptionOrNull());
@@ -152,3 +179,9 @@ class ActivitiesViewModel extends ChangeNotifier {
     return result.map((_) => unit);
   }
 }
+
+/// Provider exposing the [ActivitiesViewModel] state and notifier.
+final activitiesViewModelProvider =
+    NotifierProvider<ActivitiesViewModel, ActivitiesState>(
+  ActivitiesViewModel.new,
+);

--- a/app/lib/ui/activities/widgets/activities_screen.dart
+++ b/app/lib/ui/activities/widgets/activities_screen.dart
@@ -19,12 +19,13 @@ import 'package:go_router/go_router.dart';
 const String confirmButtonKey = 'confirm-button';
 
 class ActivitiesScreen extends HookConsumerWidget {
-  const ActivitiesScreen({required this.viewModel, super.key});
-
-  final ActivitiesViewModel viewModel;
+  const ActivitiesScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(activitiesViewModelProvider.notifier);
+    ref.watch(activitiesViewModelProvider);
+
     void listener() {
       if (viewModel.saveActivities.value.isSuccess) {
         viewModel.saveActivities.reset();
@@ -51,7 +52,6 @@ class ActivitiesScreen extends HookConsumerWidget {
       return () => viewModel.saveActivities.removeListener(listener);
     }, [viewModel]);
 
-    useListenable(viewModel);
     useListenable(viewModel.loadActivities);
     useListenable(viewModel.saveActivities);
 

--- a/app/lib/ui/results/view_models/results_viewmodel.dart
+++ b/app/lib/ui/results/view_models/results_viewmodel.dart
@@ -2,31 +2,54 @@ import 'package:compass_app/data/repositories/destination/destination_repository
 import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_repository.dart';
 import 'package:compass_app/domain/models/destination/destination.dart';
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:compass_app/config/dependencies.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:result_command/result_command.dart';
 import 'package:result_dart/result_dart.dart';
 
-class ResultsViewModel extends ChangeNotifier {
-  ResultsViewModel({
-    required DestinationRepository destinationRepository,
-    required ItineraryConfigRepository itineraryConfigRepository,
-  }) : _destinationRepository = destinationRepository,
-       _itineraryConfigRepository = itineraryConfigRepository {
+/// State for [ResultsViewModel].
+@immutable
+class ResultsState {
+  const ResultsState({
+    this.destinations = const <Destination>[],
+    this.config = const ItineraryConfig(),
+  });
+
+  final List<Destination> destinations;
+  final ItineraryConfig config;
+
+  ResultsState copyWith({
+    List<Destination>? destinations,
+    ItineraryConfig? config,
+  }) {
+    return ResultsState(
+      destinations: destinations ?? this.destinations,
+      config: config ?? this.config,
+    );
+  }
+}
+
+/// View model backed by Riverpod [Notifier].
+class ResultsViewModel extends Notifier<ResultsState> {
+  late DestinationRepository _destinationRepository;
+  late ItineraryConfigRepository _itineraryConfigRepository;
+
+  @override
+  ResultsState build() {
+    _destinationRepository = ref.read(destinationRepositoryProvider);
+    _itineraryConfigRepository = ref.read(itineraryConfigRepositoryProvider);
     updateItineraryConfig = Command1<Unit, String>(_updateItineraryConfig);
     search = Command0(_search)..execute();
+    return const ResultsState();
   }
 
   final _log = Logger('ResultsViewModel');
 
-  final DestinationRepository _destinationRepository;
-  final ItineraryConfigRepository _itineraryConfigRepository;
-
-  List<Destination> _destinations = [];
-  List<Destination> get destinations => _destinations;
-
-  ItineraryConfig? _itineraryConfig;
-  ItineraryConfig get config => _itineraryConfig ?? const ItineraryConfig();
+  /// Current state values.
+  List<Destination> get destinations => state.destinations;
+  ItineraryConfig get config => state.config;
 
   late final Command0 search;
   late final Command1<void, String> updateItineraryConfig;
@@ -44,25 +67,23 @@ class ResultsViewModel extends ChangeNotifier {
             Exception('Unknown ItineraryConfig error'),
       );
     }
-    _itineraryConfig = resultConfig.getOrThrow();
-    notifyListeners();
+    final itineraryConfig = resultConfig.getOrThrow();
+    state = state.copyWith(config: itineraryConfig);
 
     final result = await _destinationRepository.getDestinations();
     if (result.isSuccess()) {
-      _destinations =
-          result
-              .getOrThrow()
-              .where(
-                (destination) =>
-                    destination.continent == _itineraryConfig!.continent,
-              )
-              .toList();
-      _log.fine('Destinations (${_destinations.length}) loaded');
+      final list = result
+          .getOrThrow()
+          .where(
+            (destination) => destination.continent == itineraryConfig.continent,
+          )
+          .toList();
+      state = state.copyWith(destinations: list);
+      _log.fine('Destinations (${list.length}) loaded');
     } else {
       _log.warning('Failed to load destinations', result.exceptionOrNull());
     }
 
-    notifyListeners();
     return result.map((_) => unit); // sempre retorne Result<Unit>
   }
 
@@ -91,3 +112,7 @@ class ResultsViewModel extends ChangeNotifier {
     return result.map((_) => unit);
   }
 }
+
+/// Provider exposing the [ResultsViewModel].
+final resultsViewModelProvider =
+    NotifierProvider<ResultsViewModel, ResultsState>(ResultsViewModel.new);

--- a/app/lib/ui/results/widgets/results_screen.dart
+++ b/app/lib/ui/results/widgets/results_screen.dart
@@ -15,12 +15,13 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class ResultsScreen extends HookConsumerWidget {
-  const ResultsScreen({required this.viewModel, super.key});
-
-  final ResultsViewModel viewModel;
+  const ResultsScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(resultsViewModelProvider.notifier);
+    ref.watch(resultsViewModelProvider);
+
     void listener() {
       if (viewModel.updateItineraryConfig.value.isSuccess) {
         viewModel.updateItineraryConfig.reset();
@@ -43,8 +44,6 @@ class ResultsScreen extends HookConsumerWidget {
       viewModel.updateItineraryConfig.addListener(listener);
       return () => viewModel.updateItineraryConfig.removeListener(listener);
     }, [viewModel]);
-
-    useListenable(viewModel);
     useListenable(viewModel.search);
     useListenable(viewModel.updateItineraryConfig);
 

--- a/app/test/ui/activities/activities_screen_test.dart
+++ b/app/test/ui/activities/activities_screen_test.dart
@@ -5,6 +5,8 @@
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
 import 'package:compass_app/ui/activities/view_models/activities_viewmodel.dart';
 import 'package:compass_app/ui/activities/widgets/activities_screen.dart';
+import 'package:compass_app/config/dependencies.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:compass_app/ui/activities/widgets/activity_entry.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,27 +22,38 @@ void main() {
   group('ResultsScreen widget tests', () {
     late ActivitiesViewModel viewModel;
     late MockGoRouter goRouter;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = ActivitiesViewModel(
-        activityRepository: FakeActivityRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(
-          itineraryConfig: ItineraryConfig(
-            continent: 'Europe',
-            startDate: DateTime(2024),
-            endDate: DateTime(2024, 01, 31),
-            guests: 2,
-            destination: 'DESTINATION',
+      container = ProviderContainer(overrides: [
+        activityRepositoryProvider.overrideWithValue(FakeActivityRepository()),
+        itineraryConfigRepositoryProvider.overrideWith(
+          (ref) => FakeItineraryConfigRepository(
+            itineraryConfig: ItineraryConfig(
+              continent: 'Europe',
+              startDate: DateTime(2024),
+              endDate: DateTime(2024, 01, 31),
+              guests: 2,
+              destination: 'DESTINATION',
+            ),
           ),
         ),
-      );
+      ]);
+      viewModel = container.read(activitiesViewModelProvider.notifier);
       goRouter = MockGoRouter();
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadScreen(WidgetTester tester) async {
       await testApp(
         tester,
-        ActivitiesScreen(viewModel: viewModel),
+        UncontrolledProviderScope(
+          container: container,
+          child: const ActivitiesScreen(),
+        ),
         goRouter: goRouter,
       );
     }

--- a/app/test/ui/results/results_screen_test.dart
+++ b/app/test/ui/results/results_screen_test.dart
@@ -5,6 +5,8 @@
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
 import 'package:compass_app/ui/results/view_models/results_viewmodel.dart';
 import 'package:compass_app/ui/results/widgets/results_screen.dart';
+import 'package:compass_app/config/dependencies.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mocktail_image_network/mocktail_image_network.dart';
@@ -18,26 +20,39 @@ void main() {
   group('ResultsScreen widget tests', () {
     late MockGoRouter goRouter;
     late ResultsViewModel viewModel;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = ResultsViewModel(
-        destinationRepository: FakeDestinationRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(
-          itineraryConfig: ItineraryConfig(
-            continent: 'Europe',
-            startDate: DateTime(2024),
-            endDate: DateTime(2024, 01, 31),
-            guests: 2,
+      container = ProviderContainer(overrides: [
+        destinationRepositoryProvider.overrideWithValue(
+          FakeDestinationRepository(),
+        ),
+        itineraryConfigRepositoryProvider.overrideWith(
+          (ref) => FakeItineraryConfigRepository(
+            itineraryConfig: ItineraryConfig(
+              continent: 'Europe',
+              startDate: DateTime(2024),
+              endDate: DateTime(2024, 01, 31),
+              guests: 2,
+            ),
           ),
         ),
-      );
+      ]);
+      viewModel = container.read(resultsViewModelProvider.notifier);
       goRouter = MockGoRouter();
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadScreen(WidgetTester tester) async {
       await testApp(
         tester,
-        ResultsScreen(viewModel: viewModel),
+        UncontrolledProviderScope(
+          container: container,
+          child: const ResultsScreen(),
+        ),
         goRouter: goRouter,
       );
     }

--- a/app/test/ui/results/results_viewmodel_test.dart
+++ b/app/test/ui/results/results_viewmodel_test.dart
@@ -2,30 +2,44 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
 import 'package:compass_app/ui/results/view_models/results_viewmodel.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../testing/fakes/repositories/fake_destination_repository.dart';
 import '../../../testing/fakes/repositories/fake_itinerary_config_repository.dart';
 
 void main() {
   group('ResultsViewModel tests', () {
-    final viewModel = ResultsViewModel(
-      destinationRepository: FakeDestinationRepository(),
-      itineraryConfigRepository: FakeItineraryConfigRepository(
-        itineraryConfig: ItineraryConfig(
-          continent: 'Europe',
-          startDate: DateTime(2024),
-          endDate: DateTime(2024, 01, 31),
-          guests: 2,
-        ),
-      ),
-    );
+    late ProviderContainer container;
+    late ResultsViewModel viewModel;
 
-    // perform a simple test
-    // verifies that the list of items is properly loaded
-    test('should load items', () async {
+    setUp(() {
+      container = ProviderContainer(overrides: [
+        destinationRepositoryProvider.overrideWithValue(
+          FakeDestinationRepository(),
+        ),
+        itineraryConfigRepositoryProvider.overrideWith(
+          (ref) => FakeItineraryConfigRepository(
+            itineraryConfig: ItineraryConfig(
+              continent: 'Europe',
+              startDate: DateTime(2024),
+              endDate: DateTime(2024, 01, 31),
+              guests: 2,
+            ),
+          ),
+        ),
+      ]);
+      viewModel = container.read(resultsViewModelProvider.notifier);
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('should load items', () {
       expect(viewModel.destinations.length, 2);
     });
   });


### PR DESCRIPTION
## Summary
- migrate ActivitiesViewModel to Riverpod Notifier with ActivitiesState
- migrate ResultsViewModel to Riverpod Notifier with ResultsState
- update ActivitiesScreen and ResultsScreen to read view models from providers
- simplify router routes to create screens without manual view model construction
- update widget and view model tests for provider setup

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d7eb3022c8322a69abcae527ec299