### PR TITLE
Refactor Home and Search form with Riverpod

### DIFF
--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -51,33 +51,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       ),
       GoRoute(
         path: Routes.home,
-        builder: (context, state) {
-          return Consumer(
-            builder: (context, ref, _) {
-              final viewModel = HomeViewModel(
-                bookingRepository: ref.read(bookingRepositoryProvider),
-                userRepository: ref.read(userRepositoryProvider),
-              );
-              return HomeScreen(viewModel: viewModel);
-            },
-          );
-        },
+        builder: (context, state) => const HomeScreen(),
         routes: [
           GoRoute(
             path: Routes.searchRelative,
-            builder: (context, state) {
-              return Consumer(
-                builder: (context, ref, _) {
-                  final viewModel = SearchFormViewModel(
-                    continentRepository: ref.read(continentRepositoryProvider),
-                    itineraryConfigRepository: ref.read(
-                      itineraryConfigRepositoryProvider,
-                    ),
-                  );
-                  return SearchFormScreen(viewModel: viewModel);
-                },
-              );
-            },
+            builder: (context, state) => const SearchFormScreen(),
           ),
           GoRoute(
             path: Routes.resultsRelative,

--- a/app/lib/ui/home/view_models/home_viewmodel.dart
+++ b/app/lib/ui/home/view_models/home_viewmodel.dart
@@ -1,35 +1,58 @@
 import 'dart:async';
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/data/repositories/booking/booking_repository.dart';
 import 'package:compass_app/data/repositories/user/user_repository.dart';
 import 'package:compass_app/domain/models/booking/booking_summary.dart';
 import 'package:compass_app/domain/models/user/user.dart';
 import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:result_command/result_command.dart';
 import 'package:result_dart/result_dart.dart';
 
-class HomeViewModel extends ChangeNotifier {
-  HomeViewModel({
-    required BookingRepository bookingRepository,
-    required UserRepository userRepository,
-  }) : _bookingRepository = bookingRepository,
-       _userRepository = userRepository {
+/// Immutable state for [HomeViewModel].
+@immutable
+class HomeState {
+  const HomeState({
+    this.bookings = const <BookingSummary>[],
+    this.user,
+  });
+
+  final List<BookingSummary> bookings;
+  final User? user;
+
+  HomeState copyWith({
+    List<BookingSummary>? bookings,
+    User? user,
+  }) {
+    return HomeState(
+      bookings: bookings ?? this.bookings,
+      user: user ?? this.user,
+    );
+  }
+}
+
+class HomeViewModel extends Notifier<HomeState> {
+  late BookingRepository _bookingRepository;
+  late UserRepository _userRepository;
+
+  @override
+  HomeState build() {
+    _bookingRepository = ref.read(bookingRepositoryProvider);
+    _userRepository = ref.read(userRepositoryProvider);
     load = Command0(_load)..execute();
     deleteBooking = Command1(_deleteBooking);
+    return const HomeState();
   }
 
-  final BookingRepository _bookingRepository;
-  final UserRepository _userRepository;
   final _log = Logger('HomeViewModel');
-  List<BookingSummary> _bookings = [];
-  User? _user;
 
   late Command0 load;
   late Command1<void, int> deleteBooking;
 
-  List<BookingSummary> get bookings => _bookings;
-  User? get user => _user;
+  List<BookingSummary> get bookings => state.bookings;
+  User? get user => state.user;
 
   Future<Result<User>> _load() async {
     try {
@@ -41,7 +64,7 @@ class HomeViewModel extends ChangeNotifier {
           result.exceptionOrNull() ?? Exception('Failed to load bookings'),
         );
       }
-      _bookings = result.getOrThrow();
+      final bookings = result.getOrThrow();
       _log.fine('Loaded bookings');
 
       // Carregar usuário
@@ -52,49 +75,41 @@ class HomeViewModel extends ChangeNotifier {
           userResult.exceptionOrNull() ?? Exception('Failed to load user'),
         );
       }
-      _user = userResult.getOrThrow();
+      final user = userResult.getOrThrow();
       _log.fine('Loaded user');
 
-      return Success(_user!);
-    } finally {
-      notifyListeners();
+      state = state.copyWith(bookings: bookings, user: user);
+      return Success(user);
     }
   }
 
   Future<Result<Unit>> _deleteBooking(int id) async {
-    try {
-      // Deletar booking
-      final resultDelete = await _bookingRepository.delete(id);
-      if (resultDelete.isError()) {
-        _log.warning(
-          'Failed to delete booking $id',
-          resultDelete.exceptionOrNull(),
-        );
-        return Failure(
-          resultDelete.exceptionOrNull() ??
-              Exception('Failed to delete booking'),
-        );
-      }
-      _log.fine('Deleted booking $id');
-
-      // Atualizar lista de bookings
-      final resultLoadBookings = await _bookingRepository.getBookingsList();
-      if (resultLoadBookings.isError()) {
-        _log.warning(
-          'Failed to load bookings',
-          resultLoadBookings.exceptionOrNull(),
-        );
-        return Failure(
-          resultLoadBookings.exceptionOrNull() ??
-              Exception('Failed to load bookings'),
-        );
-      }
-      _bookings = resultLoadBookings.getOrThrow();
-      _log.fine('Loaded bookings');
-
-      return const Success(unit);
-    } finally {
-      notifyListeners();
+    // Delete booking
+    final resultDelete = await _bookingRepository.delete(id);
+    if (resultDelete.isError()) {
+      _log.warning('Failed to delete booking $id', resultDelete.exceptionOrNull());
+      return Failure(
+        resultDelete.exceptionOrNull() ?? Exception('Failed to delete booking'),
+      );
     }
+    _log.fine('Deleted booking $id');
+
+    // Reload bookings after deletion
+    final resultLoadBookings = await _bookingRepository.getBookingsList();
+    if (resultLoadBookings.isError()) {
+      _log.warning('Failed to load bookings', resultLoadBookings.exceptionOrNull());
+      return Failure(
+        resultLoadBookings.exceptionOrNull() ?? Exception('Failed to load bookings'),
+      );
+    }
+    final bookings = resultLoadBookings.getOrThrow();
+    state = state.copyWith(bookings: bookings);
+    _log.fine('Loaded bookings');
+
+    return const Success(unit);
   }
 }
+
+/// Provider exposing the [HomeViewModel] state and notifier.
+final homeViewModelProvider =
+    NotifierProvider<HomeViewModel, HomeState>(HomeViewModel.new);

--- a/app/lib/ui/home/widgets/home_screen.dart
+++ b/app/lib/ui/home/widgets/home_screen.dart
@@ -14,16 +14,17 @@ import 'package:compass_app/ui/home/widgets/home_title.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 const String bookingButtonKey = 'booking-button';
 
-class HomeScreen extends HookWidget {
-  const HomeScreen({required this.viewModel, super.key});
-
-  final HomeViewModel viewModel;
+class HomeScreen extends HookConsumerWidget {
+  const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(homeViewModelProvider.notifier);
+    ref.watch(homeViewModelProvider);
     void onResult() {
       if (viewModel.deleteBooking.value.isSuccess) {
         viewModel.deleteBooking.reset();

--- a/app/lib/ui/search_form/view_models/search_form_viewmodel.dart
+++ b/app/lib/ui/search_form/view_models/search_form_viewmodel.dart
@@ -1,55 +1,84 @@
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/data/repositories/continent/continent_repository.dart';
 import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_repository.dart';
 import 'package:compass_app/domain/models/continent/continent.dart';
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:result_command/result_command.dart';
 import 'package:result_dart/result_dart.dart';
 
-class SearchFormViewModel extends ChangeNotifier {
-  SearchFormViewModel({
-    required ContinentRepository continentRepository,
-    required ItineraryConfigRepository itineraryConfigRepository,
-  }) : _continentRepository = continentRepository,
-       _itineraryConfigRepository = itineraryConfigRepository {
+/// Immutable state for [SearchFormViewModel].
+@immutable
+class SearchFormState {
+  const SearchFormState({
+    this.continents = const <Continent>[],
+    this.selectedContinent,
+    this.dateRange,
+    this.guests = 0,
+  });
+
+  final List<Continent> continents;
+  final String? selectedContinent;
+  final DateTimeRange? dateRange;
+  final int guests;
+
+  bool get valid =>
+      guests > 0 && selectedContinent != null && dateRange != null;
+
+  SearchFormState copyWith({
+    List<Continent>? continents,
+    String? selectedContinent,
+    DateTimeRange? dateRange,
+    int? guests,
+  }) {
+    return SearchFormState(
+      continents: continents ?? this.continents,
+      selectedContinent: selectedContinent ?? this.selectedContinent,
+      dateRange: dateRange ?? this.dateRange,
+      guests: guests ?? this.guests,
+    );
+  }
+}
+
+class SearchFormViewModel extends Notifier<SearchFormState> {
+  late ContinentRepository _continentRepository;
+  late ItineraryConfigRepository _itineraryConfigRepository;
+
+  @override
+  SearchFormState build() {
+    _continentRepository = ref.read(continentRepositoryProvider);
+    _itineraryConfigRepository = ref.read(itineraryConfigRepositoryProvider);
     updateItineraryConfig = Command0(_updateItineraryConfig);
     load = Command0(_load)..execute();
+    return const SearchFormState();
   }
 
   final _log = Logger('SearchFormViewModel');
-  final ContinentRepository _continentRepository;
-  final ItineraryConfigRepository _itineraryConfigRepository;
-  List<Continent> _continents = [];
-  String? _selectedContinent;
-  DateTimeRange? _dateRange;
-  int _guests = 0;
 
-  bool get valid =>
-      _guests > 0 && _selectedContinent != null && _dateRange != null;
+  List<Continent> get continents => state.continents;
 
-  List<Continent> get continents => _continents;
-
-  String? get selectedContinent => _selectedContinent;
+  String? get selectedContinent => state.selectedContinent;
   set selectedContinent(String? continent) {
-    _selectedContinent = continent;
+    state = state.copyWith(selectedContinent: continent);
     _log.finest('Selected continent: $continent');
-    notifyListeners();
   }
 
-  DateTimeRange? get dateRange => _dateRange;
+  DateTimeRange? get dateRange => state.dateRange;
   set dateRange(DateTimeRange? dateRange) {
-    _dateRange = dateRange;
+    state = state.copyWith(dateRange: dateRange);
     _log.finest('Selected date range: $dateRange');
-    notifyListeners();
   }
 
-  int get guests => _guests;
+  int get guests => state.guests;
   set guests(int quantity) {
-    _guests = quantity < 0 ? 0 : quantity;
-    _log.finest('Set guests number: $_guests');
-    notifyListeners();
+    final value = quantity < 0 ? 0 : quantity;
+    state = state.copyWith(guests: value);
+    _log.finest('Set guests number: $value');
   }
+
+  bool get valid => state.valid;
 
   late final Command0 load;
   late final Command0 updateItineraryConfig;
@@ -67,12 +96,12 @@ class SearchFormViewModel extends ChangeNotifier {
   Future<Result<Unit>> _loadContinents() async {
     final result = await _continentRepository.getContinents();
     if (result.isSuccess()) {
-      _continents = result.getOrThrow();
-      _log.fine('Continents (${_continents.length}) loaded');
+      final list = result.getOrThrow();
+      state = state.copyWith(continents: list);
+      _log.fine('Continents (${list.length}) loaded');
     } else {
       _log.warning('Failed to load continents', result.exceptionOrNull());
     }
-    notifyListeners();
     return result.map((_) => unit);
   }
 
@@ -80,17 +109,18 @@ class SearchFormViewModel extends ChangeNotifier {
     final result = await _itineraryConfigRepository.getItineraryConfig();
     if (result.isSuccess()) {
       final itineraryConfig = result.getOrThrow();
-      _selectedContinent = itineraryConfig.continent;
-      if (itineraryConfig.startDate != null &&
-          itineraryConfig.endDate != null) {
-        _dateRange = DateTimeRange(
-          start: itineraryConfig.startDate!,
-          end: itineraryConfig.endDate!,
-        );
-      }
-      _guests = itineraryConfig.guests ?? 0;
+      state = state.copyWith(
+        selectedContinent: itineraryConfig.continent,
+        dateRange: itineraryConfig.startDate != null &&
+                itineraryConfig.endDate != null
+            ? DateTimeRange(
+                start: itineraryConfig.startDate!,
+                end: itineraryConfig.endDate!,
+              )
+            : null,
+        guests: itineraryConfig.guests ?? 0,
+      );
       _log.fine('ItineraryConfig loaded');
-      notifyListeners();
     } else {
       _log.warning(
         'Failed to load stored ItineraryConfig',
@@ -104,10 +134,10 @@ class SearchFormViewModel extends ChangeNotifier {
     assert(valid, 'called when valid was false');
     final result = await _itineraryConfigRepository.setItineraryConfig(
       ItineraryConfig(
-        continent: _selectedContinent,
-        startDate: _dateRange!.start,
-        endDate: _dateRange!.end,
-        guests: _guests,
+        continent: state.selectedContinent,
+        startDate: state.dateRange!.start,
+        endDate: state.dateRange!.end,
+        guests: state.guests,
       ),
     );
     if (result.isSuccess()) {
@@ -118,3 +148,7 @@ class SearchFormViewModel extends ChangeNotifier {
     return result.map((_) => unit);
   }
 }
+
+/// Provider exposing the [SearchFormViewModel] state and notifier.
+final searchFormViewModelProvider =
+    NotifierProvider<SearchFormViewModel, SearchFormState>(SearchFormViewModel.new);

--- a/app/lib/ui/search_form/widgets/search_form_screen.dart
+++ b/app/lib/ui/search_form/widgets/search_form_screen.dart
@@ -14,19 +14,20 @@ import 'package:compass_app/ui/search_form/widgets/search_form_submit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Search form screen
 ///
 /// Displays a search form with continent, date and guests selection.
 /// Tapping on the submit button opens the [ResultsScreen] screen
 /// passing the search options as query parameters.
-class SearchFormScreen extends HookWidget {
-  const SearchFormScreen({required this.viewModel, super.key});
-
-  final SearchFormViewModel viewModel;
+class SearchFormScreen extends HookConsumerWidget {
+  const SearchFormScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(searchFormViewModelProvider.notifier);
+    ref.watch(searchFormViewModelProvider);
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, r) {

--- a/app/test/ui/home/widgets/home_screen_test.dart
+++ b/app/test/ui/home/widgets/home_screen_test.dart
@@ -25,30 +25,34 @@ void main() {
     late HomeViewModel viewModel;
     late MockGoRouter goRouter;
     late FakeBookingRepository bookingRepository;
+    late ProviderContainer container;
 
     setUp(() {
       bookingRepository = FakeBookingRepository()..createBooking(kBooking);
-      viewModel = HomeViewModel(
-        bookingRepository: bookingRepository,
-        userRepository: FakeUserRepository(),
-      );
+      container = ProviderContainer(overrides: [
+        bookingRepositoryProvider.overrideWithValue(bookingRepository),
+        userRepositoryProvider.overrideWithValue(FakeUserRepository()),
+        authRepositoryProvider.overrideWith((ref) => FakeAuthRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+      ]);
+      viewModel = container.read(homeViewModelProvider.notifier);
       goRouter = MockGoRouter();
       when(() => goRouter.push(any())).thenAnswer((_) => Future.value());
+      when(() => goRouter.go(any())).thenAnswer((_) => Future.value());
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadWidget(WidgetTester tester) async {
       await testApp(
         tester,
-        ProviderScope(
-          overrides: [
-            authRepositoryProvider.overrideWith(
-              (ref) => FakeAuthRepository(),
-            ),
-            itineraryConfigRepositoryProvider.overrideWithValue(
-              FakeItineraryConfigRepository(),
-            ),
-          ],
-          child: HomeScreen(viewModel: viewModel),
+        UncontrolledProviderScope(
+          container: container,
+          child: const HomeScreen(),
         ),
         goRouter: goRouter,
       );
@@ -111,11 +115,18 @@ void main() {
       final repo = _BadFakeBookingRepository();
       await repo.createBooking(kBooking);
 
-      // Create a ViewModel with a repository that will fail to delete
-      viewModel = HomeViewModel(
-        bookingRepository: repo,
-        userRepository: FakeUserRepository(),
-      );
+      // Recreate container with failing repository
+      container.dispose();
+      container = ProviderContainer(overrides: [
+        bookingRepositoryProvider.overrideWithValue(repo),
+        userRepositoryProvider.overrideWithValue(FakeUserRepository()),
+        authRepositoryProvider.overrideWith((ref) => FakeAuthRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+      ]);
+      viewModel = container.read(homeViewModelProvider.notifier);
+
       await loadWidget(tester);
       await tester.pumpAndSettle();
 

--- a/app/test/ui/search_form/view_models/search_form_viewmodel_test.dart
+++ b/app/test/ui/search_form/view_models/search_form_viewmodel_test.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../testing/fakes/repositories/fake_continent_repository.dart';
 import '../../../../testing/fakes/repositories/fake_itinerary_config_repository.dart';
@@ -12,12 +14,20 @@ import '../../../../testing/fakes/repositories/fake_itinerary_config_repository.
 void main() {
   group('SearchFormViewModel Tests', () {
     late SearchFormViewModel viewModel;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = SearchFormViewModel(
-        continentRepository: FakeContinentRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(),
-      );
+      container = ProviderContainer(overrides: [
+        continentRepositoryProvider.overrideWithValue(FakeContinentRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+      ]);
+      viewModel = container.read(searchFormViewModelProvider.notifier);
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     test('Initial values are correct', () {

--- a/app/test/ui/search_form/widgets/search_form_continent_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_continent_test.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dart';
 import 'package:compass_app/ui/search_form/widgets/search_form_continent.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../testing/app.dart';
 import '../../../../testing/fakes/repositories/fake_continent_repository.dart';
@@ -13,16 +15,30 @@ import '../../../../testing/fakes/repositories/fake_itinerary_config_repository.
 void main() {
   group('SearchFormContinent widget tests', () {
     late SearchFormViewModel viewModel;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = SearchFormViewModel(
-        continentRepository: FakeContinentRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(),
-      );
+      container = ProviderContainer(overrides: [
+        continentRepositoryProvider.overrideWithValue(FakeContinentRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+      ]);
+      viewModel = container.read(searchFormViewModelProvider.notifier);
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadWidget(WidgetTester tester) async {
-      await testApp(tester, SearchFormContinent(viewModel: viewModel));
+      await testApp(
+        tester,
+        UncontrolledProviderScope(
+          container: container,
+          child: SearchFormContinent(viewModel: viewModel),
+        ),
+      );
     }
 
     testWidgets('Should load and select continent', (

--- a/app/test/ui/search_form/widgets/search_form_date_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_date_test.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dart';
 import 'package:compass_app/ui/search_form/widgets/search_form_date.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../testing/app.dart';
 import '../../../../testing/fakes/repositories/fake_continent_repository.dart';
@@ -14,16 +16,30 @@ import '../../../../testing/fakes/repositories/fake_itinerary_config_repository.
 void main() {
   group('SearchFormDate widget tests', () {
     late SearchFormViewModel viewModel;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = SearchFormViewModel(
-        continentRepository: FakeContinentRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(),
-      );
+      container = ProviderContainer(overrides: [
+        continentRepositoryProvider.overrideWithValue(FakeContinentRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+      ]);
+      viewModel = container.read(searchFormViewModelProvider.notifier);
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadWidget(WidgetTester tester) async {
-      await testApp(tester, SearchFormDate(viewModel: viewModel));
+      await testApp(
+        tester,
+        UncontrolledProviderScope(
+          container: container,
+          child: SearchFormDate(viewModel: viewModel),
+        ),
+      );
     }
 
     testWidgets('should display date in different month', (

--- a/app/test/ui/search_form/widgets/search_form_guests_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_guests_test.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dart';
 import 'package:compass_app/ui/search_form/widgets/search_form_guests.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../testing/app.dart';
 import '../../../../testing/fakes/repositories/fake_continent_repository.dart';
@@ -14,16 +16,30 @@ import '../../../../testing/fakes/repositories/fake_itinerary_config_repository.
 void main() {
   group('SearchFormGuests widget tests', () {
     late SearchFormViewModel viewModel;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = SearchFormViewModel(
-        continentRepository: FakeContinentRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(),
-      );
+      container = ProviderContainer(overrides: [
+        continentRepositoryProvider.overrideWithValue(FakeContinentRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+      ]);
+      viewModel = container.read(searchFormViewModelProvider.notifier);
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadWidget(WidgetTester tester) async {
-      await testApp(tester, SearchFormGuests(viewModel: viewModel));
+      await testApp(
+        tester,
+        UncontrolledProviderScope(
+          container: container,
+          child: SearchFormGuests(viewModel: viewModel),
+        ),
+      );
     }
 
     testWidgets('Increase number of guests', (WidgetTester tester) async {

--- a/app/test/ui/search_form/widgets/search_form_screen_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_screen_test.dart
@@ -22,28 +22,30 @@ void main() {
   group('SearchFormScreen widget tests', () {
     late SearchFormViewModel viewModel;
     late MockGoRouter goRouter;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = SearchFormViewModel(
-        continentRepository: FakeContinentRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(),
-      );
+      container = ProviderContainer(overrides: [
+        continentRepositoryProvider.overrideWithValue(FakeContinentRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+        authRepositoryProvider.overrideWith((ref) => FakeAuthRepository()),
+      ]);
+      viewModel = container.read(searchFormViewModelProvider.notifier);
       goRouter = MockGoRouter();
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadWidget(WidgetTester tester) async {
       await testApp(
         tester,
-        ProviderScope(
-          overrides: [
-            authRepositoryProvider.overrideWith(
-              (ref) => FakeAuthRepository(),
-            ),
-            itineraryConfigRepositoryProvider.overrideWithValue(
-              FakeItineraryConfigRepository(),
-            ),
-          ],
-          child: SearchFormScreen(viewModel: viewModel),
+        UncontrolledProviderScope(
+          container: container,
+          child: const SearchFormScreen(),
         ),
         goRouter: goRouter,
       );

--- a/app/test/ui/search_form/widgets/search_form_submit_test.dart
+++ b/app/test/ui/search_form/widgets/search_form_submit_test.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dart';
 import 'package:compass_app/ui/search_form/widgets/search_form_submit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../testing/app.dart';
@@ -17,19 +19,30 @@ void main() {
   group('SearchFormSubmit widget tests', () {
     late SearchFormViewModel viewModel;
     late MockGoRouter goRouter;
+    late ProviderContainer container;
 
     setUp(() {
-      viewModel = SearchFormViewModel(
-        continentRepository: FakeContinentRepository(),
-        itineraryConfigRepository: FakeItineraryConfigRepository(),
-      );
+      container = ProviderContainer(overrides: [
+        continentRepositoryProvider.overrideWithValue(FakeContinentRepository()),
+        itineraryConfigRepositoryProvider.overrideWithValue(
+          FakeItineraryConfigRepository(),
+        ),
+      ]);
+      viewModel = container.read(searchFormViewModelProvider.notifier);
       goRouter = MockGoRouter();
+    });
+
+    tearDown(() {
+      container.dispose();
     });
 
     Future<void> loadWidget(WidgetTester tester) async {
       await testApp(
         tester,
-        SearchFormSubmit(viewModel: viewModel),
+        UncontrolledProviderScope(
+          container: container,
+          child: SearchFormSubmit(viewModel: viewModel),
+        ),
         goRouter: goRouter,
       );
     }


### PR DESCRIPTION
## Summary
- refactor `HomeViewModel` to use Riverpod `Notifier`
- refactor `SearchFormViewModel` to use Riverpod `Notifier`
- update widgets to read view models from providers
- simplify router to build constant screens
- adapt tests for new providers

## Testing
- `flutter format -l 80 lib test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d883e4c208322add16de5b75637ac