### PR TITLE
Fix import conflicts and remove invalid listener

### DIFF
--- a/app/lib/routing/router.dart
+++ b/app/lib/routing/router.dart
@@ -18,8 +18,6 @@ import 'package:compass_app/ui/search_form/view_models/search_form_viewmodel.dar
 import 'package:compass_app/ui/search_form/widgets/search_form_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
-import 'package:go_router/go_router.dart' show GoRouterRefreshStream;
-import 'package:compass_app/ui/auth/auth_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Top go_router entry point.

--- a/app/lib/ui/home/widgets/home_screen.dart
+++ b/app/lib/ui/home/widgets/home_screen.dart
@@ -49,7 +49,7 @@ class HomeScreen extends HookConsumerWidget {
       return () => viewModel.deleteBooking.removeListener(onResult);
     }, [viewModel]);
 
-    useListenable(viewModel);
+    // Listen for changes on commands only. HomeViewModel is not a Listenable.
     useListenable(viewModel.load);
     useListenable(viewModel.deleteBooking);
 

--- a/app/lib/ui/home/widgets/home_title.dart
+++ b/app/lib/ui/home/widgets/home_title.dart
@@ -5,7 +5,6 @@
 import 'package:compass_app/config/dependencies.dart';
 import 'package:compass_app/ui/auth/logout/view_models/logout_viewmodel.dart';
 import 'package:compass_app/ui/auth/logout/widgets/logout_button.dart';
-import 'package:compass_app/ui/auth/auth_controller.dart';
 import 'package:compass_app/ui/core/localization/applocalization.dart';
 import 'package:compass_app/ui/core/themes/dimens.dart';
 import 'package:compass_app/ui/home/view_models/home_viewmodel.dart';


### PR DESCRIPTION
## Summary
- remove invalid `useListenable` call
- drop duplicate `auth_controller` imports
- trim extra `go_router` imports

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_686e804cc4e883229dc327101ce26ee9